### PR TITLE
Add RoomTag for room annotation with auto-sizing width

### DIFF
--- a/examples/example_hospital_wing.py
+++ b/examples/example_hospital_wing.py
@@ -37,12 +37,13 @@ from bimascode.drawing.primitives import (
     TextAlignment,
     TextNote2D,
 )
-from bimascode.drawing.tags import DoorTag, TagStyle
+from bimascode.drawing.tags import DoorTag, RoomTag, TagStyle
 from bimascode.drawing.view_base import ViewRange
 from bimascode.performance.representation_cache import RepresentationCache
 from bimascode.performance.spatial_index import SpatialIndex
 from bimascode.spatial.building import Building
 from bimascode.spatial.level import Level
+from bimascode.spatial.room import Room
 from bimascode.utils.materials import MaterialLibrary
 
 # Building dimensions (mm)
@@ -90,6 +91,7 @@ def create_hospital_wing(building, types):
 
     all_walls = []
     all_doors = []
+    all_rooms = []
 
     ext_wall = types["exterior_wall"]
     int_wall = types["interior_wall"]
@@ -203,6 +205,20 @@ def create_hospital_wing(building, types):
         )
         all_doors.append(door)
 
+        # Create patient room
+        patient_room = Room(
+            name="Patient Room",
+            number=str(101 + i),
+            boundary=[
+                (room_x, south_room_y),
+                (room_x + ROOM_WIDTH, south_room_y),
+                (room_x + ROOM_WIDTH, corridor_south_y),
+                (room_x, corridor_south_y),
+            ],
+            level=level,
+        )
+        all_rooms.append(patient_room)
+
     # Nurses station position (center)
     nurses_x_start = NUM_ROOMS_PER_SIDE * ROOM_WIDTH
     nurses_x_end = nurses_x_start + NURSES_STATION_WIDTH
@@ -255,6 +271,20 @@ def create_hospital_wing(building, types):
         )
         all_doors.append(door)
 
+        # Create patient room
+        patient_room = Room(
+            name="Patient Room",
+            number=str(106 + i),
+            boundary=[
+                (room_x, south_room_y),
+                (room_x + ROOM_WIDTH, south_room_y),
+                (room_x + ROOM_WIDTH, corridor_south_y),
+                (room_x, corridor_south_y),
+            ],
+            level=level,
+        )
+        all_rooms.append(patient_room)
+
     # -- Patient rooms (North side) --
     room_partition_points_north = [0]
 
@@ -282,6 +312,20 @@ def create_hospital_wing(building, types):
             mark=str(201 + i),
         )
         all_doors.append(door)
+
+        # Create patient room
+        patient_room = Room(
+            name="Patient Room",
+            number=str(201 + i),
+            boundary=[
+                (room_x, corridor_north_y),
+                (room_x + ROOM_WIDTH, corridor_north_y),
+                (room_x + ROOM_WIDTH, north_room_y),
+                (room_x, north_room_y),
+            ],
+            level=level,
+        )
+        all_rooms.append(patient_room)
 
     # North nurses station partitions
     partition = Wall(
@@ -329,6 +373,61 @@ def create_hospital_wing(building, types):
         )
         all_doors.append(door)
 
+        # Create patient room
+        patient_room = Room(
+            name="Patient Room",
+            number=str(206 + i),
+            boundary=[
+                (room_x, corridor_north_y),
+                (room_x + ROOM_WIDTH, corridor_north_y),
+                (room_x + ROOM_WIDTH, north_room_y),
+                (room_x, north_room_y),
+            ],
+            level=level,
+        )
+        all_rooms.append(patient_room)
+
+    # Create nurses station rooms (south and north)
+    nurses_station_south = Room(
+        name="Nurses Station",
+        number="NS-S",
+        boundary=[
+            (nurses_x_start, south_room_y),
+            (nurses_x_end, south_room_y),
+            (nurses_x_end, corridor_south_y),
+            (nurses_x_start, corridor_south_y),
+        ],
+        level=level,
+    )
+    all_rooms.append(nurses_station_south)
+
+    nurses_station_north = Room(
+        name="Nurses Station",
+        number="NS-N",
+        boundary=[
+            (nurses_x_start, corridor_north_y),
+            (nurses_x_end, corridor_north_y),
+            (nurses_x_end, north_room_y),
+            (nurses_x_start, north_room_y),
+        ],
+        level=level,
+    )
+    all_rooms.append(nurses_station_north)
+
+    # Create corridor room
+    corridor_room = Room(
+        name="Corridor",
+        number="CORR",
+        boundary=[
+            (0, corridor_south_y),
+            (corridor_length, corridor_south_y),
+            (corridor_length, corridor_north_y),
+            (0, corridor_north_y),
+        ],
+        level=level,
+    )
+    all_rooms.append(corridor_room)
+
     # Floor slab
     floor_boundary = [
         (0, south_room_y),
@@ -343,6 +442,7 @@ def create_hospital_wing(building, types):
         all_walls,
         all_doors,
         [floor],
+        all_rooms,
         room_partition_points_south,
         room_partition_points_north,
         nurses_x_start,
@@ -371,6 +471,7 @@ def add_door_tags(result, doors, style: TagStyle | None = None):
 
 def add_annotations(
     result,
+    rooms,
     room_points_south,
     room_points_north,
     nurses_x_start,
@@ -379,11 +480,13 @@ def add_annotations(
     south_room_y,
     north_room_y,
 ):
-    """Add dimensions and labels to the floor plan.
+    """Add dimensions and room tags to the floor plan.
 
     This demonstrates PROPER use of ChainDimension2D:
     - Dimensioning room widths along the corridor (collinear points)
     - Chain dimensions share a continuous baseline
+
+    Room labels are now added using RoomTag instead of TextNote.
     """
     dim_style = LineStyle.dimension()
 
@@ -456,88 +559,13 @@ def add_annotations(
     )
     result.dimensions.append(depth_dim_north)
 
-    # -- TEXT LABELS --
+    # -- ROOM TAGS --
+    # Room labels using RoomTag (replaces TextNote for room labels)
+    room_style = TagStyle.room_default()
+    for room in rooms:
+        result.room_tags.append(RoomTag(room=room, style=room_style))
 
-    # Room labels (South side - west wing)
-    for i in range(NUM_ROOMS_PER_SIDE):
-        room_x = i * ROOM_WIDTH + ROOM_WIDTH / 2
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(room_x, south_room_y + ROOM_DEPTH / 2),
-                content=f"ROOM\n{101 + i}",
-                height=200,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
-
-    # Room labels (South side - east wing)
-    for i in range(NUM_ROOMS_PER_SIDE):
-        room_x = nurses_x_end + i * ROOM_WIDTH + ROOM_WIDTH / 2
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(room_x, south_room_y + ROOM_DEPTH / 2),
-                content=f"ROOM\n{106 + i}",
-                height=200,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
-
-    # Room labels (North side - west wing)
-    for i in range(NUM_ROOMS_PER_SIDE):
-        room_x = i * ROOM_WIDTH + ROOM_WIDTH / 2
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(room_x, CORRIDOR_WIDTH + ROOM_DEPTH / 2),
-                content=f"ROOM\n{201 + i}",
-                height=200,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
-
-    # Room labels (North side - east wing)
-    for i in range(NUM_ROOMS_PER_SIDE):
-        room_x = nurses_x_end + i * ROOM_WIDTH + ROOM_WIDTH / 2
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(room_x, CORRIDOR_WIDTH + ROOM_DEPTH / 2),
-                content=f"ROOM\n{206 + i}",
-                height=200,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
-
-    # Nurses station labels
-    nurses_center_x = (nurses_x_start + nurses_x_end) / 2
-
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(nurses_center_x, south_room_y + ROOM_DEPTH / 2),
-            content="NURSES\nSTATION",
-            height=250,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(nurses_center_x, CORRIDOR_WIDTH + ROOM_DEPTH / 2),
-            content="NURSES\nSTATION",
-            height=250,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    # Corridor label
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(corridor_length / 2, CORRIDOR_WIDTH / 2),
-            content="CORRIDOR",
-            height=200,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    # Title
+    # Title (keep as TextNote - this is a drawing title, not a room label)
     result.text_notes.append(
         TextNote2D(
             position=Point2D(0, south_room_y - 5000),
@@ -570,6 +598,7 @@ def main():
         walls,
         doors,
         floors,
+        rooms,
         room_points_south,
         room_points_north,
         nurses_x_start,
@@ -606,9 +635,10 @@ def main():
     )
     result = floor_plan.generate(spatial_index, cache)
 
-    # Add annotations including chain dimensions
+    # Add annotations including chain dimensions and room tags
     add_annotations(
         result,
+        rooms,
         room_points_south,
         room_points_north,
         nurses_x_start,
@@ -631,6 +661,7 @@ def main():
     print(f"  Linear dimensions: {len(result.dimensions)}")
     print(f"  Text notes: {len(result.text_notes)}")
     print(f"  Door tags: {len(result.door_tags)}")
+    print(f"  Room tags: {len(result.room_tags)}")
 
     # Export DXF
     dxf_path = output_dir / "hospital_wing_plan.dxf"

--- a/examples/example_office_building.py
+++ b/examples/example_office_building.py
@@ -38,7 +38,7 @@ from bimascode.drawing.dxf_exporter import DXFExporter
 from bimascode.drawing.floor_plan_view import FloorPlanView
 from bimascode.drawing.line_styles import LineWeight
 from bimascode.drawing.primitives import Point2D, TextAlignment, TextNote2D
-from bimascode.drawing.tags import DoorTag, TagStyle, WindowTag
+from bimascode.drawing.tags import DoorTag, RoomTag, TagStyle, WindowTag
 from bimascode.drawing.section_view import SectionView
 from bimascode.drawing.view_base import ViewRange, ViewScale
 from bimascode.drawing.view_templates import CategoryVisibility, GraphicOverride, ViewTemplate
@@ -46,6 +46,7 @@ from bimascode.performance.representation_cache import RepresentationCache
 from bimascode.performance.spatial_index import SpatialIndex
 from bimascode.spatial.building import Building
 from bimascode.spatial.level import Level
+from bimascode.spatial.room import Room
 from bimascode.structure import (
     Beam,
     StructuralColumn,
@@ -260,6 +261,7 @@ def create_ground_floor(building, types):
     all_windows = []
     all_floors = []
     all_ceilings = []
+    all_rooms = []
 
     ext_wall = types["exterior_wall"]
     int_wall = types["interior_wall"]
@@ -329,6 +331,15 @@ def create_ground_floor(building, types):
     )
     all_walls.append(reception_wall)
 
+    # Create reception room
+    reception_room = Room(
+        name="Reception",
+        number="G-01",
+        boundary=[(0, 0), (reception_width, 0), (reception_width, reception_depth), (0, reception_depth)],
+        level=ground,
+    )
+    all_rooms.append(reception_room)
+
     # Meeting rooms (4 rooms along west wall, behind reception)
     meeting_room_width = 5000
     meeting_room_depth = 4000
@@ -373,10 +384,53 @@ def create_ground_floor(building, types):
         )
         all_doors.append(door)
 
+        # Create meeting room
+        meeting_room = Room(
+            name=f"Meeting {i+1}",
+            number=f"G-{i+2:02d}",
+            boundary=[
+                (0, room_y),
+                (meeting_room_width, room_y),
+                (meeting_room_width, room_y + meeting_room_depth),
+                (0, room_y + meeting_room_depth),
+            ],
+            level=ground,
+        )
+        all_rooms.append(meeting_room)
+
     # Core walls and doors
     core_walls, core_doors = create_core(ground, types, 0)
     all_walls.extend(core_walls)
     all_doors.extend(core_doors)
+
+    # Create core room
+    core_y = GRID_Y[1]
+    core_room = Room(
+        name="Core",
+        number="CORE",
+        boundary=[
+            (CORE_X, core_y),
+            (CORE_X + CORE_WIDTH, core_y),
+            (CORE_X + CORE_WIDTH, core_y + CORE_DEPTH),
+            (CORE_X, core_y + CORE_DEPTH),
+        ],
+        level=ground,
+    )
+    all_rooms.append(core_room)
+
+    # Create open workspace room (approximate - main open area)
+    open_workspace_room = Room(
+        name="Open Workspace",
+        number="G-OS",
+        boundary=[
+            (reception_width + 1000, 0),
+            (BUILDING_LENGTH, 0),
+            (BUILDING_LENGTH, BUILDING_WIDTH),
+            (reception_width + 1000, BUILDING_WIDTH),
+        ],
+        level=ground,
+    )
+    all_rooms.append(open_workspace_room)
 
     # Floor slab
     floor_boundary = [
@@ -407,7 +461,7 @@ def create_ground_floor(building, types):
     # Structure
     columns, beams = create_structural_grid(ground, types, 0)
 
-    return ground, all_walls, all_doors, all_windows, all_floors, all_ceilings, columns, beams
+    return ground, all_walls, all_doors, all_windows, all_floors, all_ceilings, columns, beams, all_rooms
 
 
 def create_first_floor(building, types):
@@ -419,6 +473,7 @@ def create_first_floor(building, types):
     all_windows = []
     all_floors = []
     all_ceilings = []
+    all_rooms = []
 
     ext_wall = types["exterior_wall"]
     int_wall = types["interior_wall"]
@@ -492,6 +547,20 @@ def create_first_floor(building, types):
         )
         all_doors.append(door)
 
+        # Create office room
+        office_room = Room(
+            name=f"Office {i+1}",
+            number=f"1-{i+1:02d}",
+            boundary=[
+                (office_x, 0),
+                (office_x + office_width, 0),
+                (office_x + office_width, office_depth),
+                (office_x, office_depth),
+            ],
+            level=first,
+        )
+        all_rooms.append(office_room)
+
     # Conference rooms along north wall (2 large rooms)
     conf_width = 8000
     conf_depth = 5000
@@ -536,10 +605,54 @@ def create_first_floor(building, types):
         )
         all_doors.append(door)
 
+        # Create conference room
+        conf_name = "Conference Room A" if i == 0 else "Conference Room B"
+        conf_room = Room(
+            name=conf_name,
+            number=f"1-C{i+1}",
+            boundary=[
+                (conf_x, conf_y),
+                (conf_x + conf_width, conf_y),
+                (conf_x + conf_width, BUILDING_WIDTH),
+                (conf_x, BUILDING_WIDTH),
+            ],
+            level=first,
+        )
+        all_rooms.append(conf_room)
+
     # Core
     core_walls, core_doors = create_core(first, types, 1)
     all_walls.extend(core_walls)
     all_doors.extend(core_doors)
+
+    # Create core room
+    core_y = GRID_Y[1]
+    core_room = Room(
+        name="Core",
+        number="CORE",
+        boundary=[
+            (CORE_X, core_y),
+            (CORE_X + CORE_WIDTH, core_y),
+            (CORE_X + CORE_WIDTH, core_y + CORE_DEPTH),
+            (CORE_X, core_y + CORE_DEPTH),
+        ],
+        level=first,
+    )
+    all_rooms.append(core_room)
+
+    # Create open workspace room (center area)
+    open_workspace_room = Room(
+        name="Open Workspace",
+        number="1-OS",
+        boundary=[
+            (0, office_depth + 1000),
+            (BUILDING_LENGTH, office_depth + 1000),
+            (BUILDING_LENGTH, conf_y - 1000),
+            (0, conf_y - 1000),
+        ],
+        level=first,
+    )
+    all_rooms.append(open_workspace_room)
 
     # Floor slab
     floor_boundary = [
@@ -581,7 +694,7 @@ def create_first_floor(building, types):
     # Structure
     columns, beams = create_structural_grid(first, types, 1)
 
-    return first, all_walls, all_doors, all_windows, all_floors, all_ceilings, columns, beams
+    return first, all_walls, all_doors, all_windows, all_floors, all_ceilings, columns, beams, all_rooms
 
 
 def create_view_templates():
@@ -669,48 +782,15 @@ def create_view_templates():
     return arch_template, struct_template
 
 
-def add_ground_floor_annotations(result):
-    """Add text notes to ground floor plan."""
-    # Room labels
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(4000, 3000),
-            content="RECEPTION",
-            height=250,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(18000, 10000),
-            content="OPEN WORKSPACE",
-            height=300,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(CORE_X + CORE_WIDTH / 2, GRID_Y[1] + CORE_DEPTH / 2),
-            content="CORE",
-            height=200,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
+def add_ground_floor_annotations(result, rooms=None):
+    """Add text notes and room tags to ground floor plan."""
+    # Room tags (using RoomTag instead of TextNote for room labels)
+    if rooms:
+        room_style = TagStyle.room_default()
+        for room in rooms:
+            result.room_tags.append(RoomTag(room=room, style=room_style))
 
-    # Meeting room labels
-    meeting_y_start = 7000
-    for i in range(3):
-        room_y = meeting_y_start + i * 4500
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(2500, room_y + 2000),
-                content=f"MEETING\n{i + 1}",
-                height=150,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
-
-    # General note
+    # General note (keep as TextNote - this is a title, not a room label)
     result.text_notes.append(
         TextNote2D(
             position=Point2D(-500, -2000),
@@ -737,63 +817,15 @@ def add_tags(result, doors, windows):
             result.window_tags.append(WindowTag(window=window, style=window_style))
 
 
-def add_first_floor_annotations(result):
-    """Add text notes to first floor plan."""
-    # Office labels
-    office_start_x = 1000
-    office_width = 4000
-    for i in range(6):
-        office_x = office_start_x + i * 4500
-        if office_x + office_width > BUILDING_LENGTH - 1000:
-            break
-        result.text_notes.append(
-            TextNote2D(
-                position=Point2D(office_x + office_width / 2, 2000),
-                content=f"OFFICE\n{i + 1}",
-                height=150,
-                alignment=TextAlignment.MIDDLE_CENTER,
-            )
-        )
+def add_first_floor_annotations(result, rooms=None):
+    """Add text notes and room tags to first floor plan."""
+    # Room tags (using RoomTag instead of TextNote for room labels)
+    if rooms:
+        room_style = TagStyle.room_default()
+        for room in rooms:
+            result.room_tags.append(RoomTag(room=room, style=room_style))
 
-    # Conference room labels
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(7000, 17500),
-            content="CONFERENCE\nROOM A",
-            height=200,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(21000, 17500),
-            content="CONFERENCE\nROOM B",
-            height=200,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    # Open workspace (positioned between conference rooms and office corridor)
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(15000, 12500),
-            content="OPEN WORKSPACE",
-            height=300,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    # Core
-    result.text_notes.append(
-        TextNote2D(
-            position=Point2D(CORE_X + CORE_WIDTH / 2, GRID_Y[1] + CORE_DEPTH / 2),
-            content="CORE",
-            height=200,
-            alignment=TextAlignment.MIDDLE_CENTER,
-        )
-    )
-
-    # General note
+    # General note (keep as TextNote - this is a title, not a room label)
     result.text_notes.append(
         TextNote2D(
             position=Point2D(-500, -2000),
@@ -815,6 +847,7 @@ def generate_floor_plan(
     add_annotations_fn=None,
     doors=None,
     windows=None,
+    rooms=None,
 ):
     """Generate and export a floor plan."""
     print(f"  Generating {name}...")
@@ -825,7 +858,7 @@ def generate_floor_plan(
 
     # Add annotations if function provided
     if add_annotations_fn:
-        add_annotations_fn(result)
+        add_annotations_fn(result, rooms=rooms)
 
     # Add door and window tags
     if doors or windows:
@@ -834,8 +867,10 @@ def generate_floor_plan(
     print(f"    Elements: {result.element_count}, Geometry: {result.total_geometry_count}")
     if result.text_notes:
         print(f"    Text notes: {len(result.text_notes)}")
-    if result.door_tags or result.window_tags:
-        print(f"    Tags: {len(result.door_tags)} doors, {len(result.window_tags)} windows")
+    if result.door_tags or result.window_tags or result.room_tags:
+        print(
+            f"    Tags: {len(result.door_tags)} doors, {len(result.window_tags)} windows, {len(result.room_tags)} rooms"
+        )
 
     exporter = DXFExporter()
     exporter.export(result, str(output_path))
@@ -881,12 +916,12 @@ def main():
 
     # Create floors
     print("\n  Ground Floor...")
-    ground, g_walls, g_doors, g_windows, g_floors, g_ceilings, g_columns, g_beams = (
+    ground, g_walls, g_doors, g_windows, g_floors, g_ceilings, g_columns, g_beams, g_rooms = (
         create_ground_floor(building, types)
     )
 
     print("  First Floor...")
-    first, f_walls, f_doors, f_windows, f_floors, f_ceilings, f_columns, f_beams = (
+    first, f_walls, f_doors, f_windows, f_floors, f_ceilings, f_columns, f_beams, f_rooms = (
         create_first_floor(building, types)
     )
 
@@ -956,6 +991,7 @@ def main():
         add_ground_floor_annotations,
         doors=g_doors,
         windows=g_windows,
+        rooms=g_rooms,
     )
     generate_floor_plan(
         "Ground Floor - Structural",
@@ -975,6 +1011,7 @@ def main():
         add_first_floor_annotations,
         doors=f_doors,
         windows=f_windows,
+        rooms=f_rooms,
     )
     generate_floor_plan(
         "First Floor - Structural",

--- a/src/bimascode/drawing/__init__.py
+++ b/src/bimascode/drawing/__init__.py
@@ -64,7 +64,7 @@ from bimascode.drawing.section_cutter import SectionCutter, get_section_cutter
 from bimascode.drawing.section_view import SectionView
 
 # Tags
-from bimascode.drawing.tags import DoorTag, Tag2D, TagShape, TagStyle, WindowTag
+from bimascode.drawing.tags import DoorTag, RoomTag, Tag2D, TagShape, TagStyle, WindowTag
 
 # View base classes
 from bimascode.drawing.view_base import (
@@ -137,6 +137,7 @@ __all__ = [
     # Tags
     "DoorTag",
     "WindowTag",
+    "RoomTag",
     "TagStyle",
     "TagShape",
     "Tag2D",

--- a/src/bimascode/drawing/dxf_exporter.py
+++ b/src/bimascode/drawing/dxf_exporter.py
@@ -20,7 +20,7 @@ from bimascode.drawing.primitives import (
     TextNote2D,
     ViewResult,
 )
-from bimascode.drawing.tags import DoorTag, TagShape, WindowTag
+from bimascode.drawing.tags import DoorTag, RoomTag, TagShape, WindowTag
 
 if TYPE_CHECKING:
     pass
@@ -122,6 +122,7 @@ class DXFExporter:
         self._export_text_notes(msp, view_result.text_notes, scale)
         self._export_door_tags(doc, msp, view_result.door_tags, scale)
         self._export_window_tags(doc, msp, view_result.window_tags, scale)
+        self._export_room_tags(doc, msp, view_result.room_tags, scale)
 
         # Save file
         doc.saveas(filepath)
@@ -149,6 +150,8 @@ class DXFExporter:
         for tag in view_result.door_tags:
             layers.add(tag.layer)
         for tag in view_result.window_tags:
+            layers.add(tag.layer)
+        for tag in view_result.room_tags:
             layers.add(tag.layer)
 
         # Create layers with standard AIA colors
@@ -543,6 +546,144 @@ class DXFExporter:
             # Add attribute with the mark value
             block_ref.add_auto_attribs({"MARK": tag.text})
 
+    def _create_room_tag_block(
+        self,
+        doc,
+        block_name: str,
+        shape: TagShape,
+        size: float,
+        width: float,
+        text_height: float,
+    ) -> None:
+        """Create a room tag block definition if it doesn't exist.
+
+        Room tags display two lines of text: room name and room number.
+        The block is sized to accommodate both lines.
+
+        Args:
+            doc: DXF document
+            block_name: Name for the block
+            shape: Tag shape (rectangle recommended for rooms)
+            size: Size of the tag symbol in mm (height for rectangle)
+            width: Width of the tag symbol in mm (for rectangle)
+            text_height: Height of the text in mm
+        """
+        if block_name in doc.blocks:
+            return
+
+        block = doc.blocks.new(name=block_name)
+        half_width = width / 2
+        half_height = size / 2
+
+        if shape == TagShape.CIRCLE:
+            # Draw circle (use larger of width/height as diameter)
+            radius = max(half_width, half_height)
+            block.add_circle(center=(0, 0), radius=radius)
+        elif shape == TagShape.HEXAGON:
+            import math
+
+            # Use larger dimension for hexagon
+            hex_size = max(half_width, half_height)
+            points = []
+            for i in range(6):
+                angle = math.pi / 6 + i * math.pi / 3
+                x = hex_size * math.cos(angle)
+                y = hex_size * math.sin(angle)
+                points.append((x, y))
+            block.add_lwpolyline(points, close=True)
+        elif shape == TagShape.RECTANGLE:
+            # Draw rectangle (default for room tags)
+            block.add_lwpolyline(
+                [
+                    (-half_width, -half_height),
+                    (half_width, -half_height),
+                    (half_width, half_height),
+                    (-half_width, half_height),
+                ],
+                close=True,
+            )
+        elif shape == TagShape.DIAMOND:
+            block.add_lwpolyline(
+                [
+                    (0, half_height),
+                    (half_width, 0),
+                    (0, -half_height),
+                    (-half_width, 0),
+                ],
+                close=True,
+            )
+
+        # Add attribute definition for room NAME (upper line)
+        line_spacing = text_height * 1.5
+        block.add_attdef(
+            tag="NAME",
+            insert=(0, line_spacing / 2),
+            dxfattribs={
+                "height": text_height,
+                "halign": 4,  # Middle center
+                "valign": 2,  # Middle
+            },
+        )
+
+        # Add attribute definition for room NUMBER (lower line)
+        block.add_attdef(
+            tag="NUMBER",
+            insert=(0, -line_spacing / 2),
+            dxfattribs={
+                "height": text_height,
+                "halign": 4,  # Middle center
+                "valign": 2,  # Middle
+            },
+        )
+
+    def _export_room_tags(
+        self,
+        doc,
+        msp,
+        tags: list[RoomTag],
+        scale: float,
+    ) -> None:
+        """Export RoomTag objects to DXF as BLOCK references with ATTRIB.
+
+        Room tags display both room name and room number as separate
+        attribute values within the block.
+        """
+        for tag in tags:
+            # Skip tags without any text
+            if not tag.name_text and not tag.number_text:
+                continue
+
+            # Create block definition if needed
+            self._create_room_tag_block(
+                doc,
+                tag.block_name,
+                tag.style.shape,
+                tag.style.size * scale,
+                tag.calculated_width * scale,
+                tag.style.text_height * scale,
+            )
+
+            # Insert block reference
+            insert_point = (
+                tag.insertion_point.x * scale,
+                tag.insertion_point.y * scale,
+            )
+
+            block_ref = msp.add_blockref(
+                tag.block_name,
+                insert=insert_point,
+                dxfattribs={
+                    "layer": tag.layer,
+                    "rotation": tag.rotation,
+                },
+            )
+
+            # Add attributes with the name and number values
+            block_ref.add_auto_attribs({
+                "NAME": tag.name_text,
+                "NUMBER": tag.number_text,
+            })
+
     def export_multiple(
         self,
         views: list[tuple[ViewResult, tuple[float, float]]],
@@ -589,6 +730,8 @@ class DXFExporter:
                 all_layers.add(tag.layer)
             for tag in view_result.window_tags:
                 all_layers.add(tag.layer)
+            for tag in view_result.room_tags:
+                all_layers.add(tag.layer)
 
         # Setup layers and line types
         for layer_name in all_layers:
@@ -610,6 +753,7 @@ class DXFExporter:
             self._export_text_notes(msp, translated.text_notes, scale)
             self._export_door_tags(doc, msp, translated.door_tags, scale)
             self._export_window_tags(doc, msp, translated.window_tags, scale)
+            self._export_room_tags(doc, msp, translated.room_tags, scale)
 
         # Save file
         doc.saveas(filepath)

--- a/src/bimascode/drawing/primitives.py
+++ b/src/bimascode/drawing/primitives.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Union
 from bimascode.drawing.line_styles import LineStyle
 
 if TYPE_CHECKING:
-    from bimascode.drawing.tags import DoorTag, WindowTag
+    from bimascode.drawing.tags import DoorTag, RoomTag, WindowTag
 
 
 @dataclass(frozen=True)
@@ -566,6 +566,7 @@ class ViewResult:
         text_notes: List of text annotations
         door_tags: List of door tags
         window_tags: List of window tags
+        room_tags: List of room tags
         view_name: Name of the view that generated this result
         generation_time: Time taken to generate in seconds
         element_count: Number of elements processed
@@ -581,6 +582,7 @@ class ViewResult:
     text_notes: list[TextNote2D] = field(default_factory=list)
     door_tags: list["DoorTag"] = field(default_factory=list)
     window_tags: list["WindowTag"] = field(default_factory=list)
+    room_tags: list["RoomTag"] = field(default_factory=list)
     view_name: str = ""
     generation_time: float = 0.0
     element_count: int = 0
@@ -599,6 +601,7 @@ class ViewResult:
             + len(self.text_notes)
             + len(self.door_tags)
             + len(self.window_tags)
+            + len(self.room_tags)
         )
 
     @property
@@ -625,6 +628,7 @@ class ViewResult:
         self.text_notes.extend(other.text_notes)
         self.door_tags.extend(other.door_tags)
         self.window_tags.extend(other.window_tags)
+        self.room_tags.extend(other.room_tags)
         self.element_count += other.element_count
         self.cache_hits += other.cache_hits
 
@@ -640,6 +644,7 @@ class ViewResult:
             text_notes=[t.translate(dx, dy) for t in self.text_notes],
             door_tags=[t.translate(dx, dy) for t in self.door_tags],
             window_tags=[t.translate(dx, dy) for t in self.window_tags],
+            room_tags=[t.translate(dx, dy) for t in self.room_tags],
             view_name=self.view_name,
             generation_time=self.generation_time,
             element_count=self.element_count,
@@ -704,6 +709,10 @@ class ViewResult:
             all_points.append(tag.insertion_point)
 
         for tag in self.window_tags:
+            # Include tag position
+            all_points.append(tag.insertion_point)
+
+        for tag in self.room_tags:
             # Include tag position
             all_points.append(tag.insertion_point)
 

--- a/src/bimascode/drawing/tags.py
+++ b/src/bimascode/drawing/tags.py
@@ -16,6 +16,7 @@ from bimascode.drawing.primitives import Point2D
 if TYPE_CHECKING:
     from bimascode.architecture.door import Door
     from bimascode.architecture.window import Window
+    from bimascode.spatial.room import Room
 
 
 class TagShape(Enum):
@@ -33,10 +34,11 @@ class TagStyle:
 
     Attributes:
         shape: Shape of the tag symbol
-        size: Size of the tag in mm (diameter for circle, width for others)
+        size: Size of the tag in mm (diameter for circle, height for rectangle)
         text_height: Height of the text in mm
         show_border: Whether to show the tag border
         layer: CAD layer name for the tag
+        width: Width of the tag in mm (only used for RECTANGLE shape, defaults to size)
     """
 
     shape: TagShape = TagShape.HEXAGON
@@ -44,6 +46,12 @@ class TagStyle:
     text_height: float = 100.0
     show_border: bool = True
     layer: str = Layer.SYMBOL
+    width: float | None = None
+
+    @property
+    def effective_width(self) -> float:
+        """Get the effective width (uses width if set, otherwise size)."""
+        return self.width if self.width is not None else self.size
 
     @classmethod
     def door_default(cls) -> TagStyle:
@@ -65,6 +73,22 @@ class TagStyle:
             text_height=150.0,
             show_border=True,
             layer=Layer.SYMBOL,
+        )
+
+    @classmethod
+    def room_default(cls) -> TagStyle:
+        """Default style for room tags (rectangle with name and number).
+
+        Note: width is None by default, which triggers auto-sizing based on
+        text length in RoomTag. Set width explicitly to override auto-sizing.
+        """
+        return cls(
+            shape=TagShape.RECTANGLE,
+            size=400.0,  # Height
+            text_height=120.0,
+            show_border=True,
+            layer=Layer.SYMBOL,
+            width=None,  # Auto-size based on text length
         )
 
 
@@ -204,5 +228,125 @@ class WindowTag:
         )
 
 
+@dataclass(frozen=True)
+class RoomTag:
+    """Tag annotation for a room element.
+
+    Displays the room's name and number at the room centroid in floor plan views.
+    Exports to DXF as a BLOCK reference with ATTRIB for the text content.
+
+    The tag displays two lines of text:
+    - Line 1: Room name (e.g., "Living Room")
+    - Line 2: Room number (e.g., "101")
+
+    Attributes:
+        room: The room element to tag
+        position: Override position (None = use room centroid)
+        style: Tag style configuration
+        rotation: Tag rotation in degrees
+
+    Example:
+        >>> room = Room("Living Room", "101", boundary, level)
+        >>> tag = RoomTag(room=room)
+        >>> tag.name_text  # "Living Room"
+        >>> tag.number_text  # "101"
+    """
+
+    room: Room
+    position: Point2D | None = None
+    style: TagStyle = field(default_factory=TagStyle.room_default)
+    rotation: float = 0.0
+
+    @property
+    def name_text(self) -> str:
+        """Get the room name text."""
+        return self.room.name or ""
+
+    @property
+    def number_text(self) -> str:
+        """Get the room number text."""
+        return self.room.number or ""
+
+    @property
+    def text(self) -> str:
+        """Get combined tag text (name and number on separate lines)."""
+        name = self.name_text
+        number = self.number_text
+        if name and number:
+            return f"{name}\n{number}"
+        return name or number
+
+    @property
+    def insertion_point(self) -> Point2D:
+        """Get the tag insertion point.
+
+        Returns the override position if set, otherwise calculates
+        from the room's centroid.
+        """
+        if self.position is not None:
+            return self.position
+
+        # Get room centroid position
+        centroid = self.room.get_centroid()
+        return Point2D(centroid[0], centroid[1])
+
+    @property
+    def layer(self) -> str:
+        """Get the layer for this tag."""
+        return self.style.layer
+
+    @property
+    def calculated_width(self) -> float:
+        """Calculate the tag width based on text content.
+
+        If style.width is explicitly set, uses that value.
+        Otherwise, auto-calculates based on the longest text line
+        using an approximate character width ratio.
+
+        Returns:
+            Width in mm that fits the text content.
+        """
+        # If width is explicitly set, use it
+        if self.style.width is not None:
+            return self.style.width
+
+        # Auto-calculate based on text length
+        # Use the longer of name or number
+        name_len = len(self.name_text)
+        number_len = len(self.number_text)
+        max_chars = max(name_len, number_len, 1)  # At least 1 char
+
+        # Approximate width: each character is ~0.8x text height for typical fonts
+        # Add padding on each side (2.5x text height total)
+        char_width = self.style.text_height * 0.8
+        padding = self.style.text_height * 2.5
+        calculated = max_chars * char_width + padding
+
+        # Minimum width to ensure tag looks reasonable
+        min_width = self.style.size  # At least as wide as it is tall
+
+        return max(calculated, min_width)
+
+    @property
+    def block_name(self) -> str:
+        """Get the DXF block name for this tag type.
+
+        Includes size, calculated width, and text_height in the name to ensure
+        unique block definitions for different style configurations.
+        """
+        width = int(self.calculated_width)
+        return f"ROOM_TAG_{self.style.shape.value}_{int(self.style.size)}_{width}_{int(self.style.text_height)}"
+
+    def translate(self, dx: float, dy: float) -> RoomTag:
+        """Return a translated copy of this tag."""
+        new_position = self.insertion_point.translate(dx, dy)
+        return RoomTag(
+            room=self.room,
+            position=new_position,
+            style=self.style,
+            rotation=self.rotation,
+        )
+
+
 # Type alias for any tag type
-Tag2D = DoorTag | WindowTag
+Tag2D = DoorTag | WindowTag | RoomTag

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,5 +1,5 @@
 """
-Tests for door and window tags.
+Tests for door, window, and room tags.
 """
 
 import pytest
@@ -11,9 +11,10 @@ from bimascode.architecture.wall_type import LayerFunction, WallType
 from bimascode.architecture.window import Window
 from bimascode.architecture.window_type import create_standard_window_type
 from bimascode.drawing.primitives import Point2D, ViewResult
-from bimascode.drawing.tags import DoorTag, TagShape, TagStyle, WindowTag
+from bimascode.drawing.tags import DoorTag, RoomTag, TagShape, TagStyle, WindowTag
 from bimascode.spatial.building import Building
 from bimascode.spatial.level import Level
+from bimascode.spatial.room import Room
 from bimascode.utils.materials import MaterialLibrary
 
 
@@ -36,6 +37,16 @@ class TestTagStyle:
         assert style.shape == TagShape.CIRCLE
         assert style.size == 450.0
         assert style.text_height == 150.0
+
+    def test_default_room_style(self):
+        """Test default room tag style."""
+        style = TagStyle.room_default()
+
+        assert style.shape == TagShape.RECTANGLE
+        assert style.size == 400.0  # Height
+        assert style.width is None  # Auto-size based on text length
+        assert style.text_height == 120.0
+        assert style.show_border is True
 
     def test_custom_style(self):
         """Test creating a custom tag style."""
@@ -369,3 +380,212 @@ class TestWindowMarkProperty:
 
         window.mark = "A"
         assert window.mark == "A"
+
+
+class TestRoomTag:
+    """Tests for RoomTag class."""
+
+    @pytest.fixture
+    def room(self):
+        """Create a room for testing."""
+        building = Building("Test Building")
+        level = Level(building, "Ground Floor", elevation=0)
+
+        # Simple rectangular boundary
+        boundary = [
+            (0, 0),
+            (4000, 0),
+            (4000, 3000),
+            (0, 3000),
+        ]
+
+        return Room("Living Room", "101", boundary, level)
+
+    def test_room_tag_creation(self, room):
+        """Test creating a room tag."""
+        tag = RoomTag(room=room)
+
+        assert tag.room == room
+        assert tag.name_text == "Living Room"
+        assert tag.number_text == "101"
+        assert tag.style.shape == TagShape.RECTANGLE
+
+    def test_room_tag_text_combined(self, room):
+        """Test combined text property."""
+        tag = RoomTag(room=room)
+
+        assert tag.text == "Living Room\n101"
+
+    def test_room_tag_insertion_point_auto(self, room):
+        """Test automatic tag position from room centroid."""
+        tag = RoomTag(room=room)
+
+        position = tag.insertion_point
+        centroid = room.get_centroid()
+
+        assert position.x == centroid[0]
+        assert position.y == centroid[1]
+        # For a 4000x3000 rectangle, centroid should be at (2000, 1500)
+        assert position.x == 2000.0
+        assert position.y == 1500.0
+
+    def test_room_tag_custom_position(self, room):
+        """Test tag with custom position override."""
+        custom_pos = Point2D(1000, 1000)
+        tag = RoomTag(room=room, position=custom_pos)
+
+        assert tag.insertion_point == custom_pos
+        assert tag.insertion_point.x == 1000
+        assert tag.insertion_point.y == 1000
+
+    def test_room_tag_custom_style(self, room):
+        """Test tag with custom style."""
+        style = TagStyle(shape=TagShape.CIRCLE, size=500.0, text_height=100.0)
+        tag = RoomTag(room=room, style=style)
+
+        assert tag.style.shape == TagShape.CIRCLE
+        assert tag.style.size == 500.0
+        assert tag.style.text_height == 100.0
+
+    def test_room_tag_translate(self, room):
+        """Test translating a room tag."""
+        tag = RoomTag(room=room)
+        original_pos = tag.insertion_point
+
+        translated = tag.translate(100, 200)
+
+        assert translated.insertion_point.x == original_pos.x + 100
+        assert translated.insertion_point.y == original_pos.y + 200
+        assert translated.room == room
+
+    def test_room_tag_block_name(self, room):
+        """Test block name generation includes style parameters."""
+        tag = RoomTag(room=room)
+
+        # Default style: size=400 (height), auto-calculated width, text_height=120
+        # "Living Room" = 11 chars, width = 11 * (120 * 0.8) + (120 * 2.5) = 1356
+        assert tag.block_name == "ROOM_TAG_RECTANGLE_400_1356_120"
+
+    def test_room_tag_calculated_width_auto(self, room):
+        """Test auto-calculated width based on text length."""
+        tag = RoomTag(room=room)
+
+        # "Living Room" = 11 chars
+        # char_width = 120 * 0.8 = 96
+        # padding = 120 * 2.5 = 300
+        # calculated = 11 * 96 + 300 = 1356
+        assert tag.calculated_width == 1356.0
+
+    def test_room_tag_calculated_width_explicit(self, room):
+        """Test explicit width overrides auto-calculation."""
+        style = TagStyle(
+            shape=TagShape.RECTANGLE,
+            size=400.0,
+            text_height=120.0,
+            width=2000.0,  # Explicit width
+        )
+        tag = RoomTag(room=room, style=style)
+
+        assert tag.calculated_width == 2000.0
+
+    def test_room_tag_layer(self, room):
+        """Test tag layer property."""
+        tag = RoomTag(room=room)
+
+        from bimascode.drawing.line_styles import Layer
+
+        assert tag.layer == Layer.SYMBOL
+
+    def test_room_tag_rotation(self, room):
+        """Test tag rotation property."""
+        tag = RoomTag(room=room, rotation=45.0)
+
+        assert tag.rotation == 45.0
+
+    def test_room_tag_empty_name(self):
+        """Test tag when room has empty name."""
+        building = Building("Test Building")
+        level = Level(building, "Ground Floor", elevation=0)
+        boundary = [(0, 0), (1000, 0), (1000, 1000), (0, 1000)]
+
+        room = Room("", "102", boundary, level)
+        tag = RoomTag(room=room)
+
+        assert tag.name_text == ""
+        assert tag.number_text == "102"
+        assert tag.text == "102"
+
+    def test_room_tag_empty_number(self):
+        """Test tag when room has empty number."""
+        building = Building("Test Building")
+        level = Level(building, "Ground Floor", elevation=0)
+        boundary = [(0, 0), (1000, 0), (1000, 1000), (0, 1000)]
+
+        room = Room("Kitchen", "", boundary, level)
+        tag = RoomTag(room=room)
+
+        assert tag.name_text == "Kitchen"
+        assert tag.number_text == ""
+        assert tag.text == "Kitchen"
+
+
+class TestViewResultWithRoomTags:
+    """Tests for ViewResult with room tag support."""
+
+    @pytest.fixture
+    def room_tag(self):
+        """Create a room tag for testing."""
+        building = Building("Test Building")
+        level = Level(building, "Ground Floor", elevation=0)
+        boundary = [(0, 0), (5000, 0), (5000, 4000), (0, 4000)]
+
+        room = Room("Office", "201", boundary, level)
+        return RoomTag(room=room)
+
+    def test_view_result_with_room_tags(self, room_tag):
+        """Test ViewResult containing room tags."""
+        result = ViewResult(room_tags=[room_tag])
+
+        assert len(result.room_tags) == 1
+        assert result.room_tags[0].name_text == "Office"
+        assert result.room_tags[0].number_text == "201"
+
+    def test_view_result_total_count_includes_room_tags(self, room_tag):
+        """Test that total_geometry_count includes room tags."""
+        result = ViewResult(room_tags=[room_tag])
+
+        assert result.total_geometry_count == 1
+
+    def test_view_result_extend_with_room_tags(self, room_tag):
+        """Test extending ViewResult preserves room tags."""
+        result1 = ViewResult()
+        result2 = ViewResult(room_tags=[room_tag])
+
+        result1.extend(result2)
+
+        assert len(result1.room_tags) == 1
+        assert result1.room_tags[0].number_text == "201"
+
+    def test_view_result_translate_with_room_tags(self, room_tag):
+        """Test translating ViewResult includes room tags."""
+        result = ViewResult(room_tags=[room_tag])
+
+        original_pos = room_tag.insertion_point
+
+        translated = result.translate(500, 300)
+
+        assert translated.room_tags[0].insertion_point.x == original_pos.x + 500
+        assert translated.room_tags[0].insertion_point.y == original_pos.y + 300
+
+    def test_view_result_bounds_includes_room_tags(self, room_tag):
+        """Test that get_bounds includes room tag positions."""
+        result = ViewResult(room_tags=[room_tag])
+
+        bounds = result.get_bounds()
+
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+
+        # Bounds should include room tag position
+        assert min_x <= room_tag.insertion_point.x <= max_x
+        assert min_y <= room_tag.insertion_point.y <= max_y


### PR DESCRIPTION
## Summary
- Add `RoomTag` class that displays room name and number at room centroid
- Auto-calculate tag rectangle width based on text length (supports explicit override via `TagStyle.width`)
- Export to DXF as BLOCK with NAME and NUMBER ATTRIB entities
- Update hospital and office examples to use RoomTag instead of TextNote for room labels

## Test plan
- [x] All 635 tests pass
- [x] Hospital wing example generates DXF with properly sized room tags
- [x] Office building example generates DXF with room tags
- [x] Auto-sizing adjusts width based on room name length
- [x] Explicit `TagStyle.width` overrides auto-calculation

🤖 Generated with [Claude Code](https://claude.ai/code)