### PR TITLE
Add Sheet class for DXF export with flat layout support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,25 @@ python examples/office_world_geometry_demo.py
   - Used by: Door, Window
   - Subclasses implement `_get_host_transform()` and `_get_local_transform()`
 
+**Expose Parameters to Driver**: All classes should provide sensible defaults for common settings, but every parameter must be configurable from driver files (example scripts, application code). Library internals should never hardcode values that users might need to customize.
+
+```python
+# GOOD - defaults with override capability
+class Sheet:
+    def __init__(
+        self,
+        size: SheetSize,
+        number: str = "",
+        margins: tuple[float, float, float, float] = (10.0, 10.0, 10.0, 10.0),  # default
+    ):
+        self._margins = margins
+
+# BAD - hardcoded internal value
+class Sheet:
+    def __init__(self, size: SheetSize, number: str = ""):
+        self._margins = (10.0, 10.0, 10.0, 10.0)  # no way to override
+```
+
 ### Critical build123d Behaviors
 
 **IMPORTANT**: build123d has non-intuitive transformation behavior that causes subtle bugs:
@@ -105,6 +124,7 @@ python examples/office_world_geometry_demo.py
 3. **`Polygon()` auto-centers at centroid** - Created polygons shift vertices to center at origin
 
 See `docs/build123d_behavior.md` for detailed explanations and examples.
+
 
 ### Module Organization
 

--- a/examples/example_hospital_wing.py
+++ b/examples/example_hospital_wing.py
@@ -37,8 +37,11 @@ from bimascode.drawing.primitives import (
     TextAlignment,
     TextNote2D,
 )
+from bimascode.drawing.section_view import SectionView
+from bimascode.drawing.sheet import Sheet, SheetMetadata
+from bimascode.drawing.sheet_sizes import SheetSize
 from bimascode.drawing.tags import DoorTag, RoomTag, TagStyle
-from bimascode.drawing.view_base import ViewRange
+from bimascode.drawing.view_base import ViewRange, ViewScale
 from bimascode.performance.representation_cache import RepresentationCache
 from bimascode.performance.spatial_index import SpatialIndex
 from bimascode.spatial.building import Building
@@ -663,11 +666,77 @@ def main():
     print(f"  Door tags: {len(result.door_tags)}")
     print(f"  Room tags: {len(result.room_tags)}")
 
-    # Export DXF
+    # Export DXF (standalone floor plan)
     dxf_path = output_dir / "hospital_wing_plan.dxf"
     exporter = DXFExporter()
     exporter.export(result, str(dxf_path))
     print(f"\n  Saved: {dxf_path.name}")
+
+    # Generate section view through patient rooms
+    # Section cuts perpendicular to corridor, through the middle of a patient room
+    # Using BIM-style section line: draw line on plan, specify look direction
+    print("\nGenerating section view...")
+    section_x = ROOM_WIDTH / 2  # Cut through center of first room
+    section_view = SectionView.from_section_line(
+        name="Section A-A",
+        start_point=(section_x, south_room_y - 1000),  # Section line start (south)
+        end_point=(section_x, north_room_y + 1000),  # Section line end (north)
+        look_direction="right",  # Looking east (right when walking south to north)
+        depth=corridor_length,  # View depth to see beyond section
+        height_range=(0, FLOOR_HEIGHT),  # Floor to ceiling
+        scale=ViewScale.SCALE_1_50,
+    )
+    section_result = section_view.generate(spatial_index, cache)
+    print(f"  Section elements: {section_result.element_count}")
+    print(f"  Section geometry: {section_result.total_geometry_count}")
+
+    # Export section DXF (standalone)
+    section_dxf_path = output_dir / "hospital_wing_section.dxf"
+    exporter.export(section_result, str(section_dxf_path))
+    print(f"  Saved: {section_dxf_path.name}")
+
+    # Create sheet with floor plan and section viewports
+    print("\nCreating construction document sheet...")
+    sheet = Sheet(
+        size=SheetSize.ARCH_D,  # 24" x 36" architectural sheet
+        number="A-101",
+        name="Level 1 Floor Plan & Section",
+        metadata=SheetMetadata(
+            project="Hospital Wing",
+            drawn_by="BIMasCode",
+            date=datetime.now().strftime("%Y-%m-%d"),
+            revision="A",
+        ),
+    )
+
+    # Add floor plan viewport (upper portion of sheet)
+    # ARCH_D is 609.6mm x 914.4mm (portrait)
+    # Floor plan is wide (~460mm at 1:100), so center it horizontally
+    # and place it in the upper 2/3 of the sheet
+    sheet.add_viewport(
+        result,
+        position=(305, 457),  # Centered on sheet
+        scale=ViewScale.SCALE_1_100,
+        name="Floor Plan",
+    )
+
+    # Add section viewport (lower portion of sheet)
+    # Section is narrower but taller - place below the floor plan
+    sheet.add_viewport(
+        section_result,
+        position=(305, 180),  # Centered horizontally, lower portion
+        scale=ViewScale.SCALE_1_50,  # Larger scale for detail
+        name="Section A-A",
+    )
+
+    print(f"  Sheet: {sheet.number} - {sheet.name}")
+    print(f"  Size: {sheet.size.name} ({sheet.size.width}mm x {sheet.size.height}mm)")
+    print(f"  Viewports: {len(sheet.viewports)}")
+
+    # Export sheet to DXF
+    sheet_dxf_path = output_dir / "hospital_wing_sheet_A101.dxf"
+    sheet.export_dxf(str(sheet_dxf_path))
+    print(f"  Saved: {sheet_dxf_path.name}")
 
     # Export IFC
     print("\nExporting IFC...")

--- a/src/bimascode/drawing/__init__.py
+++ b/src/bimascode/drawing/__init__.py
@@ -7,7 +7,7 @@ Sprint 6: Drawing Generation
 """
 
 # Primitives
-from bimascode.drawing.dxf_exporter import DXFExporter, get_dxf_exporter
+from bimascode.drawing.dxf_exporter import DXFExporter, DXFSheetExporter, get_dxf_exporter
 from bimascode.drawing.elevation_view import (
     ElevationDirection,
     ElevationView,
@@ -42,6 +42,12 @@ from bimascode.drawing.primitives import (
     Polyline2D,
     ViewResult,
 )
+
+# Sheets
+from bimascode.drawing.sheet import Sheet, SheetMetadata
+from bimascode.drawing.sheet_sizes import SheetSize
+from bimascode.drawing.title_block import TitleBlock
+from bimascode.drawing.viewport import SheetViewport
 
 # Protocols
 from bimascode.drawing.protocols import (
@@ -127,12 +133,19 @@ __all__ = [
     "GraphicOverride",
     "ViewTemplate",
     "ViewVisibilitySettings",
+    # Sheets
+    "Sheet",
+    "SheetMetadata",
+    "SheetSize",
+    "SheetViewport",
+    "TitleBlock",
     # Utilities
     "SectionCutter",
     "get_section_cutter",
     "HLRProcessor",
     "get_hlr_processor",
     "DXFExporter",
+    "DXFSheetExporter",
     "get_dxf_exporter",
     # Tags
     "DoorTag",

--- a/src/bimascode/drawing/dxf_exporter.py
+++ b/src/bimascode/drawing/dxf_exporter.py
@@ -1,7 +1,8 @@
 """DXF export for 2D views.
 
 Provides DXFExporter class for exporting ViewResult geometry
-to DXF format using ezdxf library.
+to DXF format using ezdxf library, and DXFSheetExporter for
+exporting Sheet objects with paperspace layouts.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from bimascode.drawing.primitives import (
 from bimascode.drawing.tags import DoorTag, RoomTag, TagShape, WindowTag
 
 if TYPE_CHECKING:
-    pass
+    from bimascode.drawing.sheet import Sheet
 
 
 # DXF line type patterns (dash length, gap length, ...)
@@ -321,8 +322,23 @@ class DXFExporter:
         dimensions: list[LinearDimension2D],
         scale: float,
     ) -> None:
-        """Export LinearDimension2D objects to DXF DIMENSION entities."""
+        """Export LinearDimension2D objects to DXF DIMENSION entities.
+
+        Dimension style values (text height, arrow size, etc.) are computed
+        based on the dimension offset, which scales proportionally with the
+        drawing. This ensures dimensions look correct at any scale.
+        """
         for dim in dimensions:
+            # Use offset as a reference for sizing - typical offset is 300-1000mm
+            # in model space. Scale style elements based on that.
+            # For a 500mm offset in model: text=150mm (0.3x), arrows=100mm (0.2x)
+            # After 1:100 scaling: offset=5mm, text=1.5mm, arrows=1mm
+            scaled_offset = abs(dim.offset) * scale
+            # Ensure minimum values for readability
+            text_height = max(scaled_offset * 0.3, 1.5) if scaled_offset < 50 else 150 * scale
+            arrow_size = max(scaled_offset * 0.2, 1.0) if scaled_offset < 50 else 100 * scale
+            ext_extension = max(scaled_offset * 0.1, 0.5) if scaled_offset < 50 else 50 * scale
+
             dim_override = msp.add_aligned_dim(
                 p1=(dim.start.x * scale, dim.start.y * scale),
                 p2=(dim.end.x * scale, dim.end.y * scale),
@@ -330,11 +346,12 @@ class DXFExporter:
                 text=dim.text,
                 dimstyle="Standard",
                 override={
-                    "dimtxt": 150,  # Text height in drawing units (mm)
+                    "dimtxt": text_height,  # Text height
                     "dimdec": dim.precision,  # Decimal places
-                    "dimasz": 100,  # Arrow size
-                    "dimexe": 50,  # Extension line extension
-                    "dimexo": 50,  # Extension line offset from origin
+                    "dimasz": arrow_size,  # Arrow size
+                    "dimexe": ext_extension,  # Extension line extension
+                    "dimexo": ext_extension,  # Extension line offset from origin
+                    "dimlfac": dim.dimlfac,  # Linear scale factor for text display
                 },
                 dxfattribs={"layer": dim.layer},
             )
@@ -679,10 +696,12 @@ class DXFExporter:
             )
 
             # Add attributes with the name and number values
-            block_ref.add_auto_attribs({
-                "NAME": tag.name_text,
-                "NUMBER": tag.number_text,
-            })
+            block_ref.add_auto_attribs(
+                {
+                    "NAME": tag.name_text,
+                    "NUMBER": tag.number_text,
+                }
+            )
 
     def export_multiple(
         self,
@@ -754,6 +773,370 @@ class DXFExporter:
             self._export_door_tags(doc, msp, translated.door_tags, scale)
             self._export_window_tags(doc, msp, translated.window_tags, scale)
             self._export_room_tags(doc, msp, translated.room_tags, scale)
+
+        # Save file
+        doc.saveas(filepath)
+        return True
+
+
+class DXFSheetExporter:
+    """Exports Sheet objects to DXF with paperspace layouts.
+
+    Creates a proper DXF file with:
+    - Modelspace containing all view geometry
+    - Paperspace layout with viewports looking into modelspace
+    - Title block and annotations in paperspace
+
+    Example:
+        >>> from bimascode.drawing import Sheet, SheetSize
+        >>> sheet = Sheet(size=SheetSize.ANSI_D, number="A-101")
+        >>> sheet.add_viewport(floor_plan_result, position=(300, 200), scale="1:100")
+        >>> exporter = DXFSheetExporter()
+        >>> exporter.export_sheet(sheet, "A-101.dxf")
+    """
+
+    def __init__(self, dxf_version: str = "R2013"):
+        """Initialize the sheet exporter.
+
+        Args:
+            dxf_version: DXF version (R2000 or newer required for paperspace)
+        """
+        self.dxf_version = dxf_version
+        self._check_ezdxf_available()
+        self._model_exporter = DXFExporter(dxf_version)
+
+    def _check_ezdxf_available(self) -> bool:
+        """Check if ezdxf is available."""
+        try:
+            import ezdxf
+
+            self._ezdxf = ezdxf
+            return True
+        except ImportError:
+            self._ezdxf = None
+            return False
+
+    @property
+    def is_available(self) -> bool:
+        """Check if DXF export is available."""
+        return self._ezdxf is not None
+
+    def export_sheet(
+        self,
+        sheet: Sheet,
+        filepath: str,
+    ) -> bool:
+        """Export a Sheet to DXF file with paperspace layout.
+
+        Creates a DXF file with:
+        1. All viewport contents in modelspace (offset to prevent overlap)
+        2. A paperspace layout with the sheet size
+        3. DXF VIEWPORT entities linking paperspace to modelspace content
+        4. Title block geometry in paperspace
+        5. Sheet annotations in paperspace
+
+        Args:
+            sheet: Sheet to export
+            filepath: Output file path
+
+        Returns:
+            True if export succeeded
+        """
+        if not self.is_available:
+            raise ImportError("ezdxf is required for DXF export")
+
+        # Create new DXF document
+        doc = self._ezdxf.new(self.dxf_version, setup=True)
+        msp = doc.modelspace()
+
+        # Setup layers and line types
+        self._setup_layers_from_sheet(doc, sheet)
+        self._model_exporter._setup_linetypes(doc)
+
+        # Export all viewport contents to modelspace
+        # Track bounds for each viewport's content in modelspace
+        viewport_modelspace_data: list[dict] = []
+        current_offset_x = 0.0
+
+        for viewport in sheet.viewports:
+            # Get view result bounds
+            bounds = viewport.view_result.get_bounds()
+            if bounds is None:
+                viewport_modelspace_data.append(None)
+                continue
+
+            # Calculate center in model coordinates
+            model_center_x = (bounds[0] + bounds[2]) / 2 + current_offset_x
+            model_center_y = (bounds[1] + bounds[3]) / 2
+            model_width = bounds[2] - bounds[0]
+            model_height = bounds[3] - bounds[1]
+
+            # Translate view content and export to modelspace
+            translated = viewport.view_result.translate(current_offset_x, 0)
+            self._export_view_result_to_layout(doc, msp, translated, scale=1.0)
+
+            viewport_modelspace_data.append(
+                {
+                    "center_x": model_center_x,
+                    "center_y": model_center_y,
+                    "width": model_width,
+                    "height": model_height,
+                }
+            )
+
+            # Offset next viewport to prevent overlap (add margin)
+            current_offset_x += model_width + 5000  # 5m gap between views
+
+        # Create paperspace layout
+        layout_name = self._get_layout_name(sheet)
+
+        # Get or create the paperspace layout
+        # ezdxf creates "Layout1" by default, we'll rename or create new
+        if "Layout1" in doc.layouts:
+            psp = doc.layouts.get("Layout1")
+            psp.rename(layout_name)
+        else:
+            psp = doc.layouts.new(layout_name)
+
+        # Setup page size
+        # Note: ezdxf page_setup uses (width, height) in mm
+        psp.page_setup(
+            size=(sheet.size.width, sheet.size.height),
+            margins=sheet.margins,  # (left, bottom, right, top)
+        )
+
+        # Create VIEWPORTS layer (will be turned off to hide viewport frames)
+        if "DEFPOINTS" not in doc.layers:
+            doc.layers.add("DEFPOINTS")
+
+        # Add viewports to paperspace
+        for i, viewport in enumerate(sheet.viewports):
+            ms_data = viewport_modelspace_data[i]
+            if ms_data is None:
+                continue
+
+            # Calculate viewport dimensions on paper
+            vp_width = viewport.effective_width
+            vp_height = viewport.effective_height
+
+            # View height in modelspace units (for zoom level)
+            view_height = vp_height / viewport.scale.ratio
+
+            # Create the viewport entity
+            psp.add_viewport(
+                center=(viewport.position.x, viewport.position.y),
+                size=(vp_width, vp_height),
+                view_center_point=(ms_data["center_x"], ms_data["center_y"]),
+                view_height=view_height,
+                status=2,  # Enable viewport (1=off, 2=on)
+                dxfattribs={"layer": "DEFPOINTS"},
+            )
+
+        # Export title block to paperspace (if present)
+        if sheet.title_block and sheet.title_block.has_geometry():
+            self._export_view_result_to_layout(doc, psp, sheet.title_block.geometry, scale=1.0)
+
+        # Export sheet annotations to paperspace
+        if sheet.annotations.total_geometry_count > 0:
+            self._export_view_result_to_layout(doc, psp, sheet.annotations, scale=1.0)
+
+        # Save file
+        doc.saveas(filepath)
+        return True
+
+    def _get_layout_name(self, sheet: Sheet) -> str:
+        """Generate a layout name from sheet properties.
+
+        Args:
+            sheet: Sheet to get name from
+
+        Returns:
+            Layout name string
+        """
+        if sheet.number and sheet.name:
+            return f"{sheet.number} - {sheet.name}"
+        elif sheet.number:
+            return sheet.number
+        elif sheet.name:
+            return sheet.name
+        else:
+            return "Sheet"
+
+    def _setup_layers_from_sheet(self, doc, sheet: Sheet) -> None:
+        """Create required layers from all sheet content.
+
+        Args:
+            doc: DXF document
+            sheet: Sheet containing viewports and annotations
+        """
+        # Collect all layers from all viewports
+        all_layers = set()
+
+        for viewport in sheet.viewports:
+            self._collect_layers_from_view_result(viewport.view_result, all_layers)
+
+        # Collect from title block
+        if sheet.title_block and sheet.title_block.geometry:
+            self._collect_layers_from_view_result(sheet.title_block.geometry, all_layers)
+
+        # Collect from annotations
+        self._collect_layers_from_view_result(sheet.annotations, all_layers)
+
+        # Create layers with standard AIA colors
+        layer_colors = {
+            Layer.WALL: 7,
+            Layer.WALL_FIRE: 1,
+            Layer.DOOR: 6,
+            Layer.WINDOW: 4,
+            Layer.FLOOR: 8,
+            Layer.CEILING: 9,
+            Layer.COLUMN: 3,
+            Layer.BEAM: 3,
+            Layer.ANNOTATION: 7,
+            Layer.DIMENSION: 7,
+            Layer.SYMBOL: 7,
+            "0": 7,
+        }
+
+        for layer_name in all_layers:
+            if layer_name not in doc.layers:
+                color = layer_colors.get(layer_name, 7)
+                doc.layers.add(name=layer_name, color=color)
+
+    def _collect_layers_from_view_result(self, view_result: ViewResult, layers: set) -> None:
+        """Collect all layer names from a ViewResult.
+
+        Args:
+            view_result: ViewResult to scan
+            layers: Set to add layer names to
+        """
+        for line in view_result.lines:
+            layers.add(line.layer)
+        for arc in view_result.arcs:
+            layers.add(arc.layer)
+        for polyline in view_result.polylines:
+            layers.add(polyline.layer)
+        for hatch in view_result.hatches:
+            layers.add(hatch.layer)
+        for dim in view_result.dimensions:
+            layers.add(dim.layer)
+        for chain in view_result.chain_dimensions:
+            layers.add(chain.layer)
+        for text in view_result.text_notes:
+            layers.add(text.layer)
+        for tag in view_result.door_tags:
+            layers.add(tag.layer)
+        for tag in view_result.window_tags:
+            layers.add(tag.layer)
+        for tag in view_result.room_tags:
+            layers.add(tag.layer)
+
+    def _export_view_result_to_layout(
+        self, doc, layout, view_result: ViewResult, scale: float
+    ) -> None:
+        """Export ViewResult geometry to a layout (modelspace or paperspace).
+
+        Args:
+            doc: DXF document
+            layout: Layout to export to (modelspace or paperspace)
+            view_result: ViewResult to export
+            scale: Scale factor to apply
+        """
+        self._model_exporter._export_lines(layout, view_result.lines, scale)
+        self._model_exporter._export_arcs(layout, view_result.arcs, scale)
+        self._model_exporter._export_polylines(layout, view_result.polylines, scale)
+        self._model_exporter._export_hatches(layout, view_result.hatches, scale)
+        self._model_exporter._export_dimensions(layout, view_result.dimensions, scale)
+        self._model_exporter._export_chain_dimensions(layout, view_result.chain_dimensions, scale)
+        self._model_exporter._export_text_notes(layout, view_result.text_notes, scale)
+        self._model_exporter._export_door_tags(doc, layout, view_result.door_tags, scale)
+        self._model_exporter._export_window_tags(doc, layout, view_result.window_tags, scale)
+        self._model_exporter._export_room_tags(doc, layout, view_result.room_tags, scale)
+
+    def export_sheet_flat(
+        self,
+        sheet: Sheet,
+        filepath: str,
+    ) -> bool:
+        """Export a Sheet to DXF as a flat modelspace layout.
+
+        This exports the sheet layout directly to modelspace without using
+        DXF viewports/paperspace. Each viewport's content is scaled and
+        positioned at its sheet location. This works with any DXF viewer.
+
+        Args:
+            sheet: Sheet to export
+            filepath: Output file path
+
+        Returns:
+            True if export succeeded
+        """
+        if not self.is_available:
+            raise ImportError("ezdxf is required for DXF export")
+
+        # Create new DXF document
+        doc = self._ezdxf.new(self.dxf_version, setup=True)
+        msp = doc.modelspace()
+
+        # Setup layers and line types
+        self._setup_layers_from_sheet(doc, sheet)
+        self._model_exporter._setup_linetypes(doc)
+
+        # Export each viewport's content, scaled and positioned on sheet
+        for viewport in sheet.viewports:
+            bounds = viewport.view_result.get_bounds()
+            if bounds is None:
+                continue
+
+            # Calculate view center in model coordinates
+            model_center_x = (bounds[0] + bounds[2]) / 2
+            model_center_y = (bounds[1] + bounds[3]) / 2
+
+            # Calculate translation to position view at viewport location on sheet
+            # The viewport position is the center of where the view should appear
+            # Scale factor converts model units to sheet units
+            scale = viewport.scale.ratio
+
+            # Translate: shift so model center aligns with viewport position
+            # First scale, then translate
+            offset_x = viewport.position.x - model_center_x * scale
+            offset_y = viewport.position.y - model_center_y * scale
+
+            # Scale and translate the view content
+            scaled_view = viewport.view_result.scale_and_translate(
+                scale, offset_x, offset_y
+            )
+
+            # Export to modelspace
+            self._export_view_result_to_layout(doc, msp, scaled_view, scale=1.0)
+
+        # Export title block to modelspace (if present)
+        if sheet.title_block and sheet.title_block.has_geometry():
+            self._export_view_result_to_layout(
+                doc, msp, sheet.title_block.geometry, scale=1.0
+            )
+
+        # Export sheet annotations to modelspace
+        if sheet.annotations.total_geometry_count > 0:
+            self._export_view_result_to_layout(doc, msp, sheet.annotations, scale=1.0)
+
+        # Draw sheet border (optional - helps visualize sheet bounds)
+        msp.add_line(
+            (0, 0), (sheet.size.width, 0), dxfattribs={"layer": "0", "color": 8}
+        )
+        msp.add_line(
+            (sheet.size.width, 0),
+            (sheet.size.width, sheet.size.height),
+            dxfattribs={"layer": "0", "color": 8},
+        )
+        msp.add_line(
+            (sheet.size.width, sheet.size.height),
+            (0, sheet.size.height),
+            dxfattribs={"layer": "0", "color": 8},
+        )
+        msp.add_line(
+            (0, sheet.size.height), (0, 0), dxfattribs={"layer": "0", "color": 8}
+        )
 
         # Save file
         doc.saveas(filepath)

--- a/src/bimascode/drawing/primitives.py
+++ b/src/bimascode/drawing/primitives.py
@@ -55,6 +55,19 @@ class Point2D:
         """
         return Point2D(self.x + dx, self.y + dy)
 
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> Point2D:
+        """Return a new point scaled and translated.
+
+        Args:
+            scale: Scale factor (applied first)
+            dx: X translation (applied after scaling)
+            dy: Y translation (applied after scaling)
+
+        Returns:
+            Scaled and translated Point2D
+        """
+        return Point2D(self.x * scale + dx, self.y * scale + dy)
+
     def rotate(self, angle: float, origin: Point2D | None = None) -> Point2D:
         """Return a new point rotated around an origin.
 
@@ -134,6 +147,15 @@ class Line2D:
             layer=self.layer,
         )
 
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> Line2D:
+        """Return a scaled and translated copy of this line."""
+        return Line2D(
+            start=self.start.scale_and_translate(scale, dx, dy),
+            end=self.end.scale_and_translate(scale, dx, dy),
+            style=self.style,
+            layer=self.layer,
+        )
+
     def reverse(self) -> Line2D:
         """Return a copy with start and end swapped."""
         return Line2D(
@@ -200,6 +222,17 @@ class Arc2D:
         return Arc2D(
             center=self.center.translate(dx, dy),
             radius=self.radius,
+            start_angle=self.start_angle,
+            end_angle=self.end_angle,
+            style=self.style,
+            layer=self.layer,
+        )
+
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> Arc2D:
+        """Return a scaled and translated copy of this arc."""
+        return Arc2D(
+            center=self.center.scale_and_translate(scale, dx, dy),
+            radius=self.radius * scale,
             start_angle=self.start_angle,
             end_angle=self.end_angle,
             style=self.style,
@@ -292,6 +325,15 @@ class Polyline2D:
             layer=self.layer,
         )
 
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> Polyline2D:
+        """Return a scaled and translated copy of this polyline."""
+        return Polyline2D(
+            points=[p.scale_and_translate(scale, dx, dy) for p in self.points],
+            closed=self.closed,
+            style=self.style,
+            layer=self.layer,
+        )
+
 
 @dataclass
 class Hatch2D:
@@ -326,6 +368,17 @@ class Hatch2D:
             boundary=[p.translate(dx, dy) for p in self.boundary],
             pattern=self.pattern,
             scale=self.scale,
+            rotation=self.rotation,
+            color=self.color,
+            layer=self.layer,
+        )
+
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> Hatch2D:
+        """Return a scaled and translated copy of this hatch."""
+        return Hatch2D(
+            boundary=[p.scale_and_translate(scale, dx, dy) for p in self.boundary],
+            pattern=self.pattern,
+            scale=self.scale * scale,
             rotation=self.rotation,
             color=self.color,
             layer=self.layer,
@@ -397,6 +450,18 @@ class TextNote2D:
             layer=self.layer,
         )
 
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> TextNote2D:
+        """Return a scaled and translated copy of this text note."""
+        return TextNote2D(
+            position=self.position.scale_and_translate(scale, dx, dy),
+            content=self.content,
+            height=self.height * scale,
+            alignment=self.alignment,
+            rotation=self.rotation,
+            width=self.width * scale,
+            layer=self.layer,
+        )
+
 
 @dataclass(frozen=True)
 class LinearDimension2D:
@@ -422,6 +487,7 @@ class LinearDimension2D:
     precision: int = 0
     style: LineStyle = field(default_factory=LineStyle.default)
     layer: str = "G-ANNO-DIMS"
+    dimlfac: float = 1.0  # Linear scale factor for dimension text display
 
     @property
     def distance(self) -> float:
@@ -455,6 +521,28 @@ class LinearDimension2D:
             layer=self.layer,
         )
 
+    def scale_and_translate(
+        self, scale: float, dx: float, dy: float
+    ) -> LinearDimension2D:
+        """Return a scaled and translated copy.
+
+        The dimlfac is set to maintain correct dimension text display.
+        When geometry is scaled down (e.g., 0.01 for 1:100), dimlfac is
+        set to the inverse (100) so dimension text shows model values.
+        """
+        # Accumulate dimlfac - if already scaled, multiply
+        new_dimlfac = self.dimlfac / scale if scale != 0 else self.dimlfac
+        return LinearDimension2D(
+            start=self.start.scale_and_translate(scale, dx, dy),
+            end=self.end.scale_and_translate(scale, dx, dy),
+            offset=self.offset * scale,
+            text=self.text,
+            precision=self.precision,
+            style=self.style,
+            layer=self.layer,
+            dimlfac=new_dimlfac,
+        )
+
 
 @dataclass(frozen=True)
 class ChainDimension2D:
@@ -485,6 +573,7 @@ class ChainDimension2D:
     precision: int = 0
     style: LineStyle = field(default_factory=LineStyle.default)
     layer: str = "G-ANNO-DIMS"
+    dimlfac: float = 1.0  # Linear scale factor for dimension text display
 
     def __post_init__(self):
         """Validate that at least 2 points are provided."""
@@ -515,6 +604,7 @@ class ChainDimension2D:
                     precision=self.precision,
                     style=self.style,
                     layer=self.layer,
+                    dimlfac=self.dimlfac,
                 )
             )
         return result
@@ -536,6 +626,26 @@ class ChainDimension2D:
             precision=self.precision,
             style=self.style,
             layer=self.layer,
+        )
+
+    def scale_and_translate(
+        self, scale: float, dx: float, dy: float
+    ) -> ChainDimension2D:
+        """Return a scaled and translated copy.
+
+        The dimlfac is set to maintain correct dimension text display.
+        When geometry is scaled down (e.g., 0.01 for 1:100), dimlfac is
+        set to the inverse (100) so dimension text shows model values.
+        """
+        new_dimlfac = self.dimlfac / scale if scale != 0 else self.dimlfac
+        return ChainDimension2D(
+            points=tuple(p.scale_and_translate(scale, dx, dy) for p in self.points),
+            offset=self.offset * scale,
+            text=self.text,
+            precision=self.precision,
+            style=self.style,
+            layer=self.layer,
+            dimlfac=new_dimlfac,
         )
 
 
@@ -645,6 +755,52 @@ class ViewResult:
             door_tags=[t.translate(dx, dy) for t in self.door_tags],
             window_tags=[t.translate(dx, dy) for t in self.window_tags],
             room_tags=[t.translate(dx, dy) for t in self.room_tags],
+            view_name=self.view_name,
+            generation_time=self.generation_time,
+            element_count=self.element_count,
+            cache_hits=self.cache_hits,
+        )
+
+    def scale_and_translate(
+        self, scale: float, dx: float, dy: float
+    ) -> ViewResult:
+        """Return a scaled and translated copy of all geometry.
+
+        Applies scaling first (from origin), then translation.
+
+        Args:
+            scale: Scale factor
+            dx: X translation (applied after scaling)
+            dy: Y translation (applied after scaling)
+
+        Returns:
+            New ViewResult with transformed geometry
+        """
+        return ViewResult(
+            lines=[line.scale_and_translate(scale, dx, dy) for line in self.lines],
+            arcs=[arc.scale_and_translate(scale, dx, dy) for arc in self.arcs],
+            polylines=[
+                pl.scale_and_translate(scale, dx, dy) for pl in self.polylines
+            ],
+            hatches=[h.scale_and_translate(scale, dx, dy) for h in self.hatches],
+            dimensions=[
+                d.scale_and_translate(scale, dx, dy) for d in self.dimensions
+            ],
+            chain_dimensions=[
+                c.scale_and_translate(scale, dx, dy) for c in self.chain_dimensions
+            ],
+            text_notes=[
+                t.scale_and_translate(scale, dx, dy) for t in self.text_notes
+            ],
+            door_tags=[
+                t.scale_and_translate(scale, dx, dy) for t in self.door_tags
+            ],
+            window_tags=[
+                t.scale_and_translate(scale, dx, dy) for t in self.window_tags
+            ],
+            room_tags=[
+                t.scale_and_translate(scale, dx, dy) for t in self.room_tags
+            ],
             view_name=self.view_name,
             generation_time=self.generation_time,
             element_count=self.element_count,

--- a/src/bimascode/drawing/section_view.py
+++ b/src/bimascode/drawing/section_view.py
@@ -6,8 +6,9 @@ through building models.
 
 from __future__ import annotations
 
+import math
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from bimascode.drawing.hlr_processor import get_hlr_processor
 from bimascode.drawing.line_styles import Layer, LineStyle
@@ -34,8 +35,25 @@ class SectionView(ViewBase):
     - Visible: Behind the cut plane, visible (medium lines)
     - Hidden: Behind visible elements (dashed lines)
 
-    Example:
-        >>> # Section along X axis at Y=5000
+    There are two ways to create a section view:
+
+    1. **BIM-style (recommended)**: Use `from_section_line()` to define
+       the section like in Revit - draw a line on plan and specify
+       which direction you're looking from:
+
+        >>> # Section through building, looking east
+        >>> view = SectionView.from_section_line(
+        ...     "Section A-A",
+        ...     start_point=(2000, -5000),   # Section line start on plan
+        ...     end_point=(2000, 8000),      # Section line end on plan
+        ...     look_direction="right",      # Looking right of line direction
+        ...     depth=50000,
+        ... )
+
+    2. **Geometry-style**: Use the constructor directly with plane
+       point and normal for precise control:
+
+        >>> # Section along X axis at Y=5000, looking north
         >>> view = SectionView(
         ...     "Section A-A",
         ...     plane_point=(0, 5000, 0),
@@ -79,10 +97,101 @@ class SectionView(ViewBase):
         self._template = template
         self.show_hidden_lines = show_hidden_lines
 
+    @classmethod
+    def from_section_line(
+        cls,
+        name: str,
+        start_point: tuple[float, float],
+        end_point: tuple[float, float],
+        look_direction: Literal["left", "right"] = "right",
+        depth: float = 50000.0,
+        height_range: tuple[float, float] | None = None,
+        scale: ViewScale = ViewScale.SCALE_1_50,
+        crop_region: ViewCropRegion | None = None,
+        template=None,
+        show_hidden_lines: bool = True,
+    ) -> "SectionView":
+        """Create a section view from a section line on plan.
+
+        This is the BIM-like way to define sections: draw a line on plan
+        showing where the cut happens, then specify which direction you're
+        looking from.
+
+        Args:
+            name: View name (e.g., "Section A-A")
+            start_point: Section line start point (x, y) on plan
+            end_point: Section line end point (x, y) on plan
+            look_direction: Which side of the line to look from:
+                - "right": Standing at start, looking right of the line direction
+                - "left": Standing at start, looking left of the line direction
+            depth: How far behind the cut to show elements (mm)
+            height_range: Optional (min_z, max_z) to limit vertical extent
+            scale: View scale
+            crop_region: Optional crop region
+            template: Optional view template for visibility control
+            show_hidden_lines: Whether to show hidden lines
+
+        Returns:
+            SectionView configured for the section line
+
+        Example:
+            >>> # Section through patient rooms, looking east
+            >>> section = SectionView.from_section_line(
+            ...     name="Section A-A",
+            ...     start_point=(2000, -5000),  # South end of section line
+            ...     end_point=(2000, 8000),     # North end of section line
+            ...     look_direction="right",     # Looking east (right of N direction)
+            ...     depth=50000,
+            ... )
+        """
+        # Calculate line direction vector (in 2D)
+        dx = end_point[0] - start_point[0]
+        dy = end_point[1] - start_point[1]
+        length = math.sqrt(dx * dx + dy * dy)
+
+        if length < 1e-10:
+            raise ValueError("Section line start and end points cannot be the same")
+
+        # Normalize line direction
+        line_dir_x = dx / length
+        line_dir_y = dy / length
+
+        # Calculate perpendicular (normal) direction
+        # "right" means rotate line direction 90 degrees clockwise
+        # "left" means rotate line direction 90 degrees counter-clockwise
+        if look_direction == "right":
+            # Clockwise rotation: (x, y) -> (y, -x)
+            normal_x = line_dir_y
+            normal_y = -line_dir_x
+        else:  # "left"
+            # Counter-clockwise rotation: (x, y) -> (-y, x)
+            normal_x = -line_dir_y
+            normal_y = line_dir_x
+
+        # Plane point is on the section line (use midpoint for stability)
+        plane_point = (
+            (start_point[0] + end_point[0]) / 2,
+            (start_point[1] + end_point[1]) / 2,
+            0.0,  # Z=0, height range handles vertical extent
+        )
+
+        # Plane normal is the look direction (horizontal, Z=0)
+        plane_normal = (normal_x, normal_y, 0.0)
+
+        return cls(
+            name=name,
+            plane_point=plane_point,
+            plane_normal=plane_normal,
+            depth=depth,
+            height_range=height_range,
+            scale=scale,
+            crop_region=crop_region,
+            template=template,
+            show_hidden_lines=show_hidden_lines,
+        )
+
     def _normalize(self, v: tuple[float, float, float]) -> tuple[float, float, float]:
         """Normalize a vector."""
-        import math
-
         length = math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2)
         if length < 1e-10:
             return (0, 1, 0)  # Default to Y direction

--- a/src/bimascode/drawing/sheet.py
+++ b/src/bimascode/drawing/sheet.py
@@ -1,0 +1,348 @@
+"""Drawing sheet for DXF paperspace layouts.
+
+Defines Sheet class for assembling views, title blocks, and annotations
+into a printable sheet layout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bimascode.drawing.primitives import Point2D, ViewResult
+from bimascode.drawing.sheet_sizes import SheetSize
+from bimascode.drawing.view_base import ViewScale
+from bimascode.drawing.viewport import SheetViewport
+
+if TYPE_CHECKING:
+    from bimascode.drawing.title_block import TitleBlock
+
+
+@dataclass
+class SheetMetadata:
+    """Metadata for a sheet.
+
+    Contains project and drawing information that may be displayed
+    in the title block or used for document management.
+
+    Attributes:
+        project: Project name
+        drawn_by: Name of person who created the drawing
+        checked_by: Name of reviewer
+        date: Drawing date (string format, e.g., "2026-03-25")
+        revision: Revision number/letter
+        scale: Primary scale notation (informational, e.g., "1:100")
+        custom_fields: Additional metadata fields
+    """
+
+    project: str = ""
+    drawn_by: str = ""
+    checked_by: str = ""
+    date: str = ""
+    revision: str = ""
+    scale: str = ""
+    custom_fields: dict[str, str] = field(default_factory=dict)
+
+
+class Sheet:
+    """A drawing sheet with viewports and title block.
+
+    Represents a single plottable sheet in DXF paperspace. Contains
+    viewports (scaled windows into modelspace views), a title block,
+    and sheet-level annotations.
+
+    Following the "Expose Parameters to Driver" pattern, all settings
+    have sensible defaults but can be overridden from driver code.
+
+    Attributes:
+        size: Sheet dimensions (SheetSize)
+        number: Sheet number (e.g., "A-101")
+        name: Sheet name (e.g., "Ground Floor Plan")
+        metadata: Additional sheet metadata
+        margins: Sheet margins (left, bottom, right, top) in mm
+
+    Example:
+        >>> from bimascode.drawing import Sheet, SheetSize
+        >>> sheet = Sheet(
+        ...     size=SheetSize.ANSI_D,
+        ...     number="A-101",
+        ...     name="Ground Floor Plan",
+        ... )
+        >>> sheet.add_viewport(floor_plan_result, position=(300, 200), scale="1:100")
+        >>> sheet.export_dxf("A-101.dxf")
+    """
+
+    def __init__(
+        self,
+        size: SheetSize | str,
+        number: str = "",
+        name: str = "",
+        metadata: SheetMetadata | None = None,
+        margins: tuple[float, float, float, float] = (10.0, 10.0, 10.0, 10.0),
+    ):
+        """Initialize a sheet.
+
+        Args:
+            size: Sheet size (SheetSize instance or string like "ANSI D")
+            number: Sheet number (e.g., "A-101")
+            name: Sheet name (e.g., "Ground Floor Plan")
+            metadata: Optional metadata
+            margins: Sheet margins (left, bottom, right, top) in mm
+        """
+        if isinstance(size, str):
+            self._size = SheetSize.from_string(size)
+        else:
+            self._size = size
+
+        self._number = number
+        self._name = name
+        self._metadata = metadata or SheetMetadata()
+        self._margins = margins
+
+        self._viewports: list[SheetViewport] = []
+        self._title_block: TitleBlock | None = None
+        self._annotations: ViewResult = ViewResult()
+
+    # --- Properties ---
+
+    @property
+    def size(self) -> SheetSize:
+        """Get sheet size."""
+        return self._size
+
+    @property
+    def number(self) -> str:
+        """Get sheet number."""
+        return self._number
+
+    @number.setter
+    def number(self, value: str) -> None:
+        """Set sheet number."""
+        self._number = value
+
+    @property
+    def name(self) -> str:
+        """Get sheet name."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set sheet name."""
+        self._name = value
+
+    @property
+    def metadata(self) -> SheetMetadata:
+        """Get sheet metadata."""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, value: SheetMetadata) -> None:
+        """Set sheet metadata."""
+        self._metadata = value
+
+    @property
+    def viewports(self) -> list[SheetViewport]:
+        """Get list of viewports on this sheet (copy)."""
+        return list(self._viewports)
+
+    @property
+    def title_block(self) -> TitleBlock | None:
+        """Get title block."""
+        return self._title_block
+
+    @property
+    def margins(self) -> tuple[float, float, float, float]:
+        """Get margins (left, bottom, right, top) in mm."""
+        return self._margins
+
+    @margins.setter
+    def margins(self, value: tuple[float, float, float, float]) -> None:
+        """Set margins (left, bottom, right, top) in mm."""
+        self._margins = value
+
+    @property
+    def printable_area(self) -> tuple[float, float, float, float]:
+        """Get printable area bounds (min_x, min_y, max_x, max_y) in mm."""
+        left, bottom, right, top = self._margins
+        return (
+            left,
+            bottom,
+            self._size.width - right,
+            self._size.height - top,
+        )
+
+    @property
+    def printable_width(self) -> float:
+        """Get printable width in mm."""
+        bounds = self.printable_area
+        return bounds[2] - bounds[0]
+
+    @property
+    def printable_height(self) -> float:
+        """Get printable height in mm."""
+        bounds = self.printable_area
+        return bounds[3] - bounds[1]
+
+    @property
+    def annotations(self) -> ViewResult:
+        """Get sheet annotations."""
+        return self._annotations
+
+    # --- Viewport Management ---
+
+    def add_viewport(
+        self,
+        view_result: ViewResult,
+        position: tuple[float, float] | Point2D,
+        scale: ViewScale | str,
+        width: float | None = None,
+        height: float | None = None,
+        name: str = "",
+    ) -> SheetViewport:
+        """Add a viewport to the sheet.
+
+        Args:
+            view_result: Generated view content to display
+            position: Center point of viewport on sheet (mm)
+            scale: Display scale (ViewScale or string like "1:100")
+            width: Optional viewport width in mm (auto if None)
+            height: Optional viewport height in mm (auto if None)
+            name: Optional viewport name
+
+        Returns:
+            The created SheetViewport
+        """
+        if isinstance(position, tuple):
+            position = Point2D(position[0], position[1])
+
+        if isinstance(scale, str):
+            scale = ViewScale.from_string(scale)
+
+        viewport = SheetViewport(
+            view_result=view_result,
+            position=position,
+            scale=scale,
+            width=width,
+            height=height,
+            name=name,
+        )
+
+        self._viewports.append(viewport)
+        return viewport
+
+    def remove_viewport(self, viewport: SheetViewport) -> bool:
+        """Remove a viewport from the sheet.
+
+        Args:
+            viewport: Viewport to remove
+
+        Returns:
+            True if viewport was removed, False if not found
+        """
+        if viewport in self._viewports:
+            self._viewports.remove(viewport)
+            return True
+        return False
+
+    def clear_viewports(self) -> None:
+        """Remove all viewports from the sheet."""
+        self._viewports.clear()
+
+    def get_viewport_by_name(self, name: str) -> SheetViewport | None:
+        """Find a viewport by name.
+
+        Args:
+            name: Viewport name to find
+
+        Returns:
+            Matching viewport or None
+        """
+        for vp in self._viewports:
+            if vp.name == name:
+                return vp
+        return None
+
+    # --- Title Block ---
+
+    def set_title_block(
+        self,
+        title_block: TitleBlock,
+        position: tuple[float, float] | Point2D | None = None,
+    ) -> None:
+        """Set the sheet's title block.
+
+        Args:
+            title_block: Title block to use
+            position: Optional override position (uses title_block.position if None)
+        """
+        from bimascode.drawing.title_block import TitleBlock as TB
+
+        if position is not None:
+            if isinstance(position, tuple):
+                position = Point2D(position[0], position[1])
+            # Create new title block with updated position
+            title_block = TB(
+                name=title_block.name,
+                position=position,
+                fields=title_block.fields.copy(),
+                geometry=title_block.geometry,
+            )
+
+        self._title_block = title_block
+
+    def remove_title_block(self) -> None:
+        """Remove the title block from the sheet."""
+        self._title_block = None
+
+    # --- Annotations ---
+
+    def add_annotation(self, geometry: ViewResult) -> None:
+        """Add annotation geometry to the sheet.
+
+        Annotations are placed directly on the sheet in paperspace,
+        not through a viewport.
+
+        Args:
+            geometry: 2D geometry to add
+        """
+        self._annotations.extend(geometry)
+
+    def clear_annotations(self) -> None:
+        """Remove all annotations from the sheet."""
+        self._annotations = ViewResult()
+
+    # --- Export ---
+
+    def export_dxf(
+        self,
+        filepath: str,
+        dxf_version: str = "R2013",
+        flat: bool = True,
+    ) -> bool:
+        """Export sheet to DXF file.
+
+        Args:
+            filepath: Output file path
+            dxf_version: DXF version (R2000 or newer for paperspace)
+            flat: If True (default), export as flat modelspace layout that
+                works with any DXF viewer. If False, export with proper
+                paperspace/viewport structure (requires viewer support).
+
+        Returns:
+            True if export succeeded
+        """
+        from bimascode.drawing.dxf_exporter import DXFSheetExporter
+
+        exporter = DXFSheetExporter(dxf_version=dxf_version)
+        if flat:
+            return exporter.export_sheet_flat(self, filepath)
+        else:
+            return exporter.export_sheet(self, filepath)
+
+    # --- String Representation ---
+
+    def __repr__(self) -> str:
+        return (
+            f"Sheet(number='{self._number}', name='{self._name}', "
+            f"size={self._size.name}, viewports={len(self._viewports)})"
+        )

--- a/src/bimascode/drawing/sheet_sizes.py
+++ b/src/bimascode/drawing/sheet_sizes.py
@@ -1,0 +1,160 @@
+"""Standard sheet sizes for drawing sheets.
+
+Defines SheetSize frozen dataclass with standard ISO, ANSI, and ARCH sizes.
+All dimensions are in millimeters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class SheetSize:
+    """Standard sheet size definition.
+
+    Attributes:
+        name: Human-readable name (e.g., "A1", "ANSI D")
+        width: Sheet width in mm
+        height: Sheet height in mm
+
+    Example:
+        >>> size = SheetSize.ANSI_D
+        >>> print(f"{size.name}: {size.width}mm x {size.height}mm")
+        ANSI D: 863.6mm x 558.8mm
+    """
+
+    name: str
+    width: float  # mm
+    height: float  # mm
+
+    # ISO sizes (mm)
+    A0: ClassVar[SheetSize]
+    A1: ClassVar[SheetSize]
+    A2: ClassVar[SheetSize]
+    A3: ClassVar[SheetSize]
+    A4: ClassVar[SheetSize]
+
+    # ANSI sizes (converted to mm)
+    ANSI_A: ClassVar[SheetSize]
+    ANSI_B: ClassVar[SheetSize]
+    ANSI_C: ClassVar[SheetSize]
+    ANSI_D: ClassVar[SheetSize]
+    ANSI_E: ClassVar[SheetSize]
+
+    # ARCH sizes (converted to mm)
+    ARCH_A: ClassVar[SheetSize]
+    ARCH_B: ClassVar[SheetSize]
+    ARCH_C: ClassVar[SheetSize]
+    ARCH_D: ClassVar[SheetSize]
+    ARCH_E: ClassVar[SheetSize]
+
+    @property
+    def size_tuple(self) -> tuple[float, float]:
+        """Return (width, height) tuple."""
+        return (self.width, self.height)
+
+    @property
+    def landscape(self) -> bool:
+        """Check if sheet is landscape orientation."""
+        return self.width > self.height
+
+    @property
+    def portrait(self) -> bool:
+        """Check if sheet is portrait orientation."""
+        return self.height > self.width
+
+    @property
+    def area(self) -> float:
+        """Get sheet area in square mm."""
+        return self.width * self.height
+
+    @classmethod
+    def from_string(cls, name: str) -> SheetSize:
+        """Look up sheet size by name.
+
+        Supports various name formats:
+        - "A1", "A2", etc. for ISO sizes
+        - "ANSI D", "ANSI_D", "ANSI-D" for ANSI sizes
+        - "ARCH D", "ARCH_D", "ARCH-D" for ARCH sizes
+
+        Args:
+            name: Sheet size name
+
+        Returns:
+            Matching SheetSize
+
+        Raises:
+            ValueError: If size name is not recognized
+        """
+        # Normalize name: uppercase, replace spaces/hyphens with underscores
+        normalized = name.upper().replace(" ", "_").replace("-", "_")
+
+        # Map of normalized names to sizes
+        size_map = {
+            # ISO
+            "A0": cls.A0,
+            "A1": cls.A1,
+            "A2": cls.A2,
+            "A3": cls.A3,
+            "A4": cls.A4,
+            # ANSI
+            "ANSI_A": cls.ANSI_A,
+            "ANSI_B": cls.ANSI_B,
+            "ANSI_C": cls.ANSI_C,
+            "ANSI_D": cls.ANSI_D,
+            "ANSI_E": cls.ANSI_E,
+            # ARCH
+            "ARCH_A": cls.ARCH_A,
+            "ARCH_B": cls.ARCH_B,
+            "ARCH_C": cls.ARCH_C,
+            "ARCH_D": cls.ARCH_D,
+            "ARCH_E": cls.ARCH_E,
+        }
+
+        if normalized in size_map:
+            return size_map[normalized]
+
+        raise ValueError(
+            f"Unknown sheet size: '{name}'. " f"Valid sizes: {', '.join(sorted(size_map.keys()))}"
+        )
+
+    @classmethod
+    def custom(cls, width: float, height: float, name: str = "Custom") -> SheetSize:
+        """Create a custom sheet size.
+
+        Args:
+            width: Sheet width in mm
+            height: Sheet height in mm
+            name: Optional name for the custom size
+
+        Returns:
+            Custom SheetSize instance
+        """
+        return cls(name=name, width=width, height=height)
+
+
+# Initialize ISO sizes (mm)
+# ISO 216 standard: A0 = 841 x 1189, each subsequent size is half the previous
+SheetSize.A0 = SheetSize("A0", 841.0, 1189.0)
+SheetSize.A1 = SheetSize("A1", 594.0, 841.0)
+SheetSize.A2 = SheetSize("A2", 420.0, 594.0)
+SheetSize.A3 = SheetSize("A3", 297.0, 420.0)
+SheetSize.A4 = SheetSize("A4", 210.0, 297.0)
+
+# Initialize ANSI sizes (inches converted to mm, 1 inch = 25.4 mm)
+# ANSI/ASME Y14.1 standard
+SheetSize.ANSI_A = SheetSize("ANSI A", 215.9, 279.4)  # 8.5" x 11"
+SheetSize.ANSI_B = SheetSize("ANSI B", 279.4, 431.8)  # 11" x 17"
+SheetSize.ANSI_C = SheetSize("ANSI C", 431.8, 558.8)  # 17" x 22"
+SheetSize.ANSI_D = SheetSize("ANSI D", 558.8, 863.6)  # 22" x 34"
+SheetSize.ANSI_E = SheetSize("ANSI E", 863.6, 1117.6)  # 34" x 44"
+
+# Initialize ARCH sizes (inches converted to mm)
+# Architectural paper sizes
+SheetSize.ARCH_A = SheetSize("ARCH A", 228.6, 304.8)  # 9" x 12"
+SheetSize.ARCH_B = SheetSize("ARCH B", 304.8, 457.2)  # 12" x 18"
+SheetSize.ARCH_C = SheetSize("ARCH C", 457.2, 609.6)  # 18" x 24"
+SheetSize.ARCH_D = SheetSize("ARCH D", 609.6, 914.4)  # 24" x 36"
+SheetSize.ARCH_E = SheetSize("ARCH E", 914.4, 1219.2)  # 36" x 48"

--- a/src/bimascode/drawing/tags.py
+++ b/src/bimascode/drawing/tags.py
@@ -53,6 +53,26 @@ class TagStyle:
         """Get the effective width (uses width if set, otherwise size)."""
         return self.width if self.width is not None else self.size
 
+    def scale(self, factor: float) -> TagStyle:
+        """Return a scaled copy of this style.
+
+        Scales size, text_height, and width by the given factor.
+
+        Args:
+            factor: Scale factor to apply
+
+        Returns:
+            New TagStyle with scaled dimensions
+        """
+        return TagStyle(
+            shape=self.shape,
+            size=self.size * factor,
+            text_height=self.text_height * factor,
+            show_border=self.show_border,
+            layer=self.layer,
+            width=self.width * factor if self.width is not None else None,
+        )
+
     @classmethod
     def door_default(cls) -> TagStyle:
         """Default style for door tags (hexagon)."""
@@ -159,6 +179,16 @@ class DoorTag:
             rotation=self.rotation,
         )
 
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> DoorTag:
+        """Return a scaled and translated copy of this tag."""
+        new_position = self.insertion_point.scale_and_translate(scale, dx, dy)
+        return DoorTag(
+            door=self.door,
+            position=new_position,
+            style=self.style.scale(scale),
+            rotation=self.rotation,
+        )
+
 
 @dataclass(frozen=True)
 class WindowTag:
@@ -224,6 +254,16 @@ class WindowTag:
             window=self.window,
             position=new_position,
             style=self.style,
+            rotation=self.rotation,
+        )
+
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> WindowTag:
+        """Return a scaled and translated copy of this tag."""
+        new_position = self.insertion_point.scale_and_translate(scale, dx, dy)
+        return WindowTag(
+            window=self.window,
+            position=new_position,
+            style=self.style.scale(scale),
             rotation=self.rotation,
         )
 
@@ -344,6 +384,16 @@ class RoomTag:
             room=self.room,
             position=new_position,
             style=self.style,
+            rotation=self.rotation,
+        )
+
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> RoomTag:
+        """Return a scaled and translated copy of this tag."""
+        new_position = self.insertion_point.scale_and_translate(scale, dx, dy)
+        return RoomTag(
+            room=self.room,
+            position=new_position,
+            style=self.style.scale(scale),
             rotation=self.rotation,
         )
 

--- a/src/bimascode/drawing/title_block.py
+++ b/src/bimascode/drawing/title_block.py
@@ -1,0 +1,162 @@
+"""Title block for drawing sheets.
+
+Defines TitleBlock dataclass for sheet title blocks.
+This is a stub implementation for Issue #40 - full title block features
+including DXF BLOCK/ATTDEF support will be implemented separately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bimascode.drawing.primitives import Point2D, ViewResult
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class TitleBlock:
+    """Title block for sheets.
+
+    A title block contains project information, sheet metadata, and
+    graphical elements placed at a standard location on sheets.
+
+    NOTE: This is a placeholder for Issue #40. Full implementation
+    will include parametric fields, company logos, standard templates,
+    and DXF BLOCK/ATTDEF/ATTRIB support.
+
+    Attributes:
+        name: Title block name/template identifier
+        position: Insertion point on sheet (typically lower-right corner)
+        fields: Dictionary of field names to values
+        geometry: Optional 2D linework for the title block border/graphics
+
+    Example:
+        >>> title_block = TitleBlock(
+        ...     name="standard_ansi_d",
+        ...     fields={
+        ...         "project_name": "One Harbor Place",
+        ...         "sheet_number": "A-101",
+        ...         "sheet_name": "Ground Floor Plan",
+        ...         "date": "2026-03-25",
+        ...         "drawn_by": "BF",
+        ...     }
+        ... )
+    """
+
+    name: str
+    position: Point2D = field(default_factory=lambda: Point2D(0, 0))
+    fields: dict[str, str] = field(default_factory=dict)
+    geometry: ViewResult | None = None
+
+    # Common field accessors for convenience
+    @property
+    def project_name(self) -> str:
+        """Get project name field value."""
+        return self.fields.get("project_name", "")
+
+    @project_name.setter
+    def project_name(self, value: str) -> None:
+        """Set project name field value."""
+        self.fields["project_name"] = value
+
+    @property
+    def sheet_number(self) -> str:
+        """Get sheet number field value."""
+        return self.fields.get("sheet_number", "")
+
+    @sheet_number.setter
+    def sheet_number(self, value: str) -> None:
+        """Set sheet number field value."""
+        self.fields["sheet_number"] = value
+
+    @property
+    def sheet_name(self) -> str:
+        """Get sheet name field value."""
+        return self.fields.get("sheet_name", "")
+
+    @sheet_name.setter
+    def sheet_name(self, value: str) -> None:
+        """Set sheet name field value."""
+        self.fields["sheet_name"] = value
+
+    @property
+    def date(self) -> str:
+        """Get date field value."""
+        return self.fields.get("date", "")
+
+    @date.setter
+    def date(self, value: str) -> None:
+        """Set date field value."""
+        self.fields["date"] = value
+
+    @property
+    def drawn_by(self) -> str:
+        """Get drawn by field value."""
+        return self.fields.get("drawn_by", "")
+
+    @drawn_by.setter
+    def drawn_by(self, value: str) -> None:
+        """Set drawn by field value."""
+        self.fields["drawn_by"] = value
+
+    @property
+    def checked_by(self) -> str:
+        """Get checked by field value."""
+        return self.fields.get("checked_by", "")
+
+    @checked_by.setter
+    def checked_by(self, value: str) -> None:
+        """Set checked by field value."""
+        self.fields["checked_by"] = value
+
+    @property
+    def revision(self) -> str:
+        """Get revision field value."""
+        return self.fields.get("revision", "")
+
+    @revision.setter
+    def revision(self, value: str) -> None:
+        """Set revision field value."""
+        self.fields["revision"] = value
+
+    @property
+    def scale(self) -> str:
+        """Get scale field value."""
+        return self.fields.get("scale", "")
+
+    @scale.setter
+    def scale(self, value: str) -> None:
+        """Set scale field value."""
+        self.fields["scale"] = value
+
+    def get_field(self, name: str, default: str = "") -> str:
+        """Get a field value by name.
+
+        Args:
+            name: Field name
+            default: Default value if field not found
+
+        Returns:
+            Field value or default
+        """
+        return self.fields.get(name, default)
+
+    def set_field(self, name: str, value: str) -> None:
+        """Set a field value by name.
+
+        Args:
+            name: Field name
+            value: Field value
+        """
+        self.fields[name] = value
+
+    def has_geometry(self) -> bool:
+        """Check if title block has graphical geometry.
+
+        Returns:
+            True if geometry is defined and non-empty
+        """
+        return self.geometry is not None and self.geometry.total_geometry_count > 0

--- a/src/bimascode/drawing/viewport.py
+++ b/src/bimascode/drawing/viewport.py
@@ -1,0 +1,135 @@
+"""Sheet viewport for placing views on sheets.
+
+Defines SheetViewport dataclass for positioning views in paperspace.
+This is a stub implementation for Issue #39 - full viewport features
+will be implemented separately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bimascode.drawing.primitives import Point2D, ViewResult
+from bimascode.drawing.view_base import ViewScale
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class SheetViewport:
+    """Viewport placing a view on a sheet.
+
+    A viewport is a window into modelspace displayed at a specific
+    location and scale on a sheet (paperspace).
+
+    NOTE: This is a placeholder for Issue #39. Full implementation
+    will include clipping boundaries, frozen layers, and rotation.
+
+    Attributes:
+        view_result: The generated view content to display
+        position: Center point of viewport on sheet (mm from sheet origin)
+        scale: Display scale (e.g., ViewScale.SCALE_1_100)
+        width: Viewport width on sheet in mm (auto-calculated if None)
+        height: Viewport height on sheet in mm (auto-calculated if None)
+        name: Optional viewport name/label
+
+    Example:
+        >>> from bimascode.drawing import ViewResult, ViewScale
+        >>> viewport = SheetViewport(
+        ...     view_result=floor_plan_result,
+        ...     position=Point2D(300, 200),
+        ...     scale=ViewScale.SCALE_1_100,
+        ... )
+    """
+
+    view_result: ViewResult
+    position: Point2D
+    scale: ViewScale
+    width: float | None = None
+    height: float | None = None
+    name: str = ""
+
+    # Placeholder fields for future #39 features
+    clip_boundary: list[Point2D] | None = None
+    frozen_layers: list[str] = field(default_factory=list)
+    rotation: float = 0.0  # degrees
+
+    @property
+    def bounds_on_sheet(self) -> tuple[float, float, float, float]:
+        """Get viewport bounds on sheet (min_x, min_y, max_x, max_y).
+
+        Returns:
+            Tuple of (min_x, min_y, max_x, max_y) in sheet coordinates (mm)
+        """
+        w = self.width if self.width is not None else self._auto_width()
+        h = self.height if self.height is not None else self._auto_height()
+        half_w, half_h = w / 2, h / 2
+        return (
+            self.position.x - half_w,
+            self.position.y - half_h,
+            self.position.x + half_w,
+            self.position.y + half_h,
+        )
+
+    @property
+    def effective_width(self) -> float:
+        """Get effective viewport width (explicit or auto-calculated)."""
+        return self.width if self.width is not None else self._auto_width()
+
+    @property
+    def effective_height(self) -> float:
+        """Get effective viewport height (explicit or auto-calculated)."""
+        return self.height if self.height is not None else self._auto_height()
+
+    def _auto_width(self) -> float:
+        """Calculate width from view content bounds and scale."""
+        bounds = self.view_result.get_bounds()
+        if bounds:
+            model_width = bounds[2] - bounds[0]
+            return model_width * self.scale.ratio
+        return 100.0  # Default fallback
+
+    def _auto_height(self) -> float:
+        """Calculate height from view content bounds and scale."""
+        bounds = self.view_result.get_bounds()
+        if bounds:
+            model_height = bounds[3] - bounds[1]
+            return model_height * self.scale.ratio
+        return 100.0  # Default fallback
+
+    @property
+    def model_bounds(self) -> tuple[float, float, float, float] | None:
+        """Get the bounds of the view content in model coordinates.
+
+        Returns:
+            Tuple of (min_x, min_y, max_x, max_y) or None if empty
+        """
+        return self.view_result.get_bounds()
+
+    @property
+    def model_center(self) -> tuple[float, float] | None:
+        """Get the center of the view content in model coordinates.
+
+        Returns:
+            Tuple of (center_x, center_y) or None if empty
+        """
+        bounds = self.view_result.get_bounds()
+        if bounds:
+            return (
+                (bounds[0] + bounds[2]) / 2,
+                (bounds[1] + bounds[3]) / 2,
+            )
+        return None
+
+    @property
+    def view_height_in_model(self) -> float:
+        """Get the viewport height in model space units.
+
+        This is used for DXF viewport configuration.
+
+        Returns:
+            Height in model units (mm)
+        """
+        return self.effective_height / self.scale.ratio

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -1,0 +1,472 @@
+"""Tests for Sheet, SheetSize, SheetViewport, and TitleBlock classes."""
+
+import pytest
+
+from bimascode.drawing import (
+    Line2D,
+    LineStyle,
+    Point2D,
+    Sheet,
+    SheetMetadata,
+    SheetSize,
+    SheetViewport,
+    TitleBlock,
+    ViewResult,
+    ViewScale,
+)
+
+
+class TestSheetSize:
+    """Tests for SheetSize class."""
+
+    def test_standard_iso_sizes_defined(self):
+        """Test that ISO sizes are defined correctly."""
+        assert SheetSize.A0.width == 841.0
+        assert SheetSize.A0.height == 1189.0
+
+        assert SheetSize.A1.width == 594.0
+        assert SheetSize.A1.height == 841.0
+
+        assert SheetSize.A4.width == 210.0
+        assert SheetSize.A4.height == 297.0
+
+    def test_standard_ansi_sizes_defined(self):
+        """Test that ANSI sizes are defined correctly."""
+        # ANSI D: 22" x 34" = 558.8mm x 863.6mm
+        assert SheetSize.ANSI_D.width == pytest.approx(558.8, rel=0.01)
+        assert SheetSize.ANSI_D.height == pytest.approx(863.6, rel=0.01)
+
+        # ANSI A: 8.5" x 11" = 215.9mm x 279.4mm
+        assert SheetSize.ANSI_A.width == pytest.approx(215.9, rel=0.01)
+        assert SheetSize.ANSI_A.height == pytest.approx(279.4, rel=0.01)
+
+    def test_standard_arch_sizes_defined(self):
+        """Test that ARCH sizes are defined correctly."""
+        # ARCH D: 24" x 36" = 609.6mm x 914.4mm
+        assert SheetSize.ARCH_D.width == pytest.approx(609.6, rel=0.01)
+        assert SheetSize.ARCH_D.height == pytest.approx(914.4, rel=0.01)
+
+    def test_from_string_iso(self):
+        """Test creating ISO size from string."""
+        size = SheetSize.from_string("A1")
+        assert size == SheetSize.A1
+
+        size = SheetSize.from_string("a1")  # lowercase
+        assert size == SheetSize.A1
+
+    def test_from_string_ansi(self):
+        """Test creating ANSI size from string."""
+        size = SheetSize.from_string("ANSI D")
+        assert size == SheetSize.ANSI_D
+
+        size = SheetSize.from_string("ANSI_D")
+        assert size == SheetSize.ANSI_D
+
+        size = SheetSize.from_string("ansi-d")
+        assert size == SheetSize.ANSI_D
+
+    def test_from_string_arch(self):
+        """Test creating ARCH size from string."""
+        size = SheetSize.from_string("ARCH D")
+        assert size == SheetSize.ARCH_D
+
+        size = SheetSize.from_string("ARCH_D")
+        assert size == SheetSize.ARCH_D
+
+    def test_from_string_invalid(self):
+        """Test that invalid size name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown sheet size"):
+            SheetSize.from_string("INVALID")
+
+    def test_custom_size(self):
+        """Test creating custom sheet size."""
+        size = SheetSize.custom(1000, 700, "Custom")
+        assert size.width == 1000
+        assert size.height == 700
+        assert size.name == "Custom"
+
+    def test_landscape_property(self):
+        """Test landscape property."""
+        # ANSI D is portrait (width=558.8 < height=863.6)
+        assert SheetSize.ANSI_D.landscape is False
+        assert SheetSize.ANSI_D.portrait is True
+
+        # ARCH D is landscape (width=609.6 < height=914.4) - also portrait
+        # Let's use a custom landscape sheet
+        landscape = SheetSize.custom(1000, 500, "Landscape")
+        assert landscape.landscape is True
+        assert landscape.portrait is False
+
+        # A4 is portrait (height > width)
+        assert SheetSize.A4.landscape is False
+        assert SheetSize.A4.portrait is True
+
+    def test_size_tuple(self):
+        """Test size_tuple property."""
+        assert SheetSize.A1.size_tuple == (594.0, 841.0)
+
+    def test_area(self):
+        """Test area property."""
+        assert SheetSize.A4.area == 210.0 * 297.0
+
+
+class TestSheetMetadata:
+    """Tests for SheetMetadata class."""
+
+    def test_default_values(self):
+        """Test default metadata values."""
+        metadata = SheetMetadata()
+        assert metadata.project == ""
+        assert metadata.drawn_by == ""
+        assert metadata.date == ""
+
+    def test_custom_values(self):
+        """Test custom metadata values."""
+        metadata = SheetMetadata(
+            project="Test Project",
+            drawn_by="BF",
+            checked_by="JS",
+            date="2026-03-25",
+            revision="A",
+        )
+        assert metadata.project == "Test Project"
+        assert metadata.drawn_by == "BF"
+        assert metadata.checked_by == "JS"
+        assert metadata.date == "2026-03-25"
+        assert metadata.revision == "A"
+
+
+class TestSheet:
+    """Tests for Sheet class."""
+
+    def test_sheet_creation(self):
+        """Test basic sheet creation."""
+        sheet = Sheet(size=SheetSize.ANSI_D, number="A-101", name="Ground Floor")
+
+        assert sheet.number == "A-101"
+        assert sheet.name == "Ground Floor"
+        assert sheet.size == SheetSize.ANSI_D
+
+    def test_sheet_from_string_size(self):
+        """Test sheet creation with string size."""
+        sheet = Sheet(size="ANSI D", number="A-101")
+
+        assert sheet.size == SheetSize.ANSI_D
+
+    def test_default_margins(self):
+        """Test default margins."""
+        sheet = Sheet(size=SheetSize.A1)
+
+        assert sheet.margins == (10.0, 10.0, 10.0, 10.0)
+
+    def test_custom_margins(self):
+        """Test custom margins."""
+        sheet = Sheet(size=SheetSize.A1, margins=(20, 15, 20, 15))
+
+        assert sheet.margins == (20, 15, 20, 15)
+
+    def test_printable_area(self):
+        """Test printable area calculation."""
+        sheet = Sheet(size=SheetSize.A1)
+        sheet.margins = (10, 10, 10, 10)
+
+        area = sheet.printable_area
+        assert area[0] == 10  # min_x
+        assert area[1] == 10  # min_y
+        assert area[2] == SheetSize.A1.width - 10  # max_x
+        assert area[3] == SheetSize.A1.height - 10  # max_y
+
+    def test_printable_dimensions(self):
+        """Test printable width and height."""
+        sheet = Sheet(size=SheetSize.A1, margins=(10, 10, 10, 10))
+
+        assert sheet.printable_width == SheetSize.A1.width - 20
+        assert sheet.printable_height == SheetSize.A1.height - 20
+
+    def test_metadata(self):
+        """Test metadata property."""
+        metadata = SheetMetadata(project="Test")
+        sheet = Sheet(size=SheetSize.A1, metadata=metadata)
+
+        assert sheet.metadata.project == "Test"
+
+    def test_repr(self):
+        """Test string representation."""
+        sheet = Sheet(size=SheetSize.ANSI_D, number="A-101", name="Ground Floor")
+
+        repr_str = repr(sheet)
+        assert "A-101" in repr_str
+        assert "Ground Floor" in repr_str
+        assert "ANSI D" in repr_str
+
+
+class TestSheetViewport:
+    """Tests for adding viewports to sheets."""
+
+    @pytest.fixture
+    def simple_view_result(self):
+        """Create a simple ViewResult for testing."""
+        return ViewResult(
+            lines=[
+                Line2D(
+                    Point2D(0, 0),
+                    Point2D(10000, 0),
+                    LineStyle.default(),
+                ),
+                Line2D(
+                    Point2D(10000, 0),
+                    Point2D(10000, 5000),
+                    LineStyle.default(),
+                ),
+            ],
+        )
+
+    def test_add_viewport(self, simple_view_result):
+        """Test adding a viewport to a sheet."""
+        sheet = Sheet(size=SheetSize.A1, number="A-101")
+
+        vp = sheet.add_viewport(
+            simple_view_result,
+            position=(300, 200),
+            scale="1:100",
+        )
+
+        assert len(sheet.viewports) == 1
+        assert vp.position == Point2D(300, 200)
+        assert vp.scale.ratio == 0.01
+
+    def test_add_viewport_with_viewscale(self, simple_view_result):
+        """Test adding viewport with ViewScale object."""
+        sheet = Sheet(size=SheetSize.A1)
+
+        vp = sheet.add_viewport(
+            simple_view_result,
+            position=Point2D(300, 200),
+            scale=ViewScale.SCALE_1_50,
+        )
+
+        assert vp.scale == ViewScale.SCALE_1_50
+
+    def test_add_multiple_viewports(self, simple_view_result):
+        """Test adding multiple viewports."""
+        sheet = Sheet(size=SheetSize.A1)
+
+        sheet.add_viewport(simple_view_result, position=(200, 300), scale="1:100")
+        sheet.add_viewport(simple_view_result, position=(500, 300), scale="1:50")
+
+        assert len(sheet.viewports) == 2
+
+    def test_remove_viewport(self, simple_view_result):
+        """Test removing a viewport."""
+        sheet = Sheet(size=SheetSize.A1)
+        vp = sheet.add_viewport(simple_view_result, position=(0, 0), scale="1:100")
+
+        result = sheet.remove_viewport(vp)
+
+        assert result is True
+        assert len(sheet.viewports) == 0
+
+    def test_remove_nonexistent_viewport(self, simple_view_result):
+        """Test removing a viewport that doesn't exist."""
+        sheet = Sheet(size=SheetSize.A1)
+        vp = SheetViewport(
+            view_result=simple_view_result,
+            position=Point2D(0, 0),
+            scale=ViewScale.SCALE_1_100,
+        )
+
+        result = sheet.remove_viewport(vp)
+
+        assert result is False
+
+    def test_clear_viewports(self, simple_view_result):
+        """Test clearing all viewports."""
+        sheet = Sheet(size=SheetSize.A1)
+        sheet.add_viewport(simple_view_result, position=(200, 300), scale="1:100")
+        sheet.add_viewport(simple_view_result, position=(500, 300), scale="1:50")
+
+        sheet.clear_viewports()
+
+        assert len(sheet.viewports) == 0
+
+    def test_get_viewport_by_name(self, simple_view_result):
+        """Test finding viewport by name."""
+        sheet = Sheet(size=SheetSize.A1)
+        sheet.add_viewport(
+            simple_view_result, position=(200, 300), scale="1:100", name="Floor Plan"
+        )
+        sheet.add_viewport(simple_view_result, position=(500, 300), scale="1:50", name="Section")
+
+        vp = sheet.get_viewport_by_name("Floor Plan")
+
+        assert vp is not None
+        assert vp.name == "Floor Plan"
+
+    def test_get_viewport_by_name_not_found(self, simple_view_result):
+        """Test finding viewport by name when not found."""
+        sheet = Sheet(size=SheetSize.A1)
+
+        vp = sheet.get_viewport_by_name("Nonexistent")
+
+        assert vp is None
+
+    def test_viewport_bounds_on_sheet(self, simple_view_result):
+        """Test viewport bounds calculation."""
+        vp = SheetViewport(
+            view_result=simple_view_result,
+            position=Point2D(300, 200),
+            scale=ViewScale.SCALE_1_100,
+            width=200,
+            height=100,
+        )
+
+        bounds = vp.bounds_on_sheet
+
+        assert bounds == (200, 150, 400, 250)  # center - half, center + half
+
+
+class TestTitleBlock:
+    """Tests for TitleBlock class."""
+
+    def test_title_block_creation(self):
+        """Test basic title block creation."""
+        tb = TitleBlock(
+            name="standard",
+            fields={
+                "project_name": "Test Project",
+                "sheet_number": "A-101",
+            },
+        )
+
+        assert tb.name == "standard"
+        assert tb.project_name == "Test Project"
+        assert tb.sheet_number == "A-101"
+
+    def test_title_block_field_setters(self):
+        """Test title block field setters."""
+        tb = TitleBlock(name="standard")
+
+        tb.project_name = "My Project"
+        tb.sheet_number = "A-102"
+        tb.drawn_by = "BF"
+
+        assert tb.project_name == "My Project"
+        assert tb.sheet_number == "A-102"
+        assert tb.drawn_by == "BF"
+
+    def test_title_block_get_set_field(self):
+        """Test generic get/set field methods."""
+        tb = TitleBlock(name="standard")
+
+        tb.set_field("custom_field", "custom_value")
+
+        assert tb.get_field("custom_field") == "custom_value"
+        assert tb.get_field("nonexistent", "default") == "default"
+
+    def test_has_geometry(self):
+        """Test has_geometry method."""
+        tb = TitleBlock(name="standard")
+        assert tb.has_geometry() is False
+
+        tb.geometry = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(100, 0), LineStyle.default())]
+        )
+        assert tb.has_geometry() is True
+
+
+class TestSheetTitleBlock:
+    """Tests for title block management on sheets."""
+
+    def test_set_title_block(self):
+        """Test setting title block on sheet."""
+        sheet = Sheet(size=SheetSize.A1, number="A-101")
+        tb = TitleBlock(name="standard")
+
+        sheet.set_title_block(tb)
+
+        assert sheet.title_block is not None
+        assert sheet.title_block.name == "standard"
+
+    def test_set_title_block_with_position(self):
+        """Test setting title block with position override."""
+        sheet = Sheet(size=SheetSize.A1)
+        tb = TitleBlock(name="standard", position=Point2D(0, 0))
+
+        sheet.set_title_block(tb, position=(100, 50))
+
+        assert sheet.title_block.position == Point2D(100, 50)
+
+    def test_remove_title_block(self):
+        """Test removing title block from sheet."""
+        sheet = Sheet(size=SheetSize.A1)
+        tb = TitleBlock(name="standard")
+        sheet.set_title_block(tb)
+
+        sheet.remove_title_block()
+
+        assert sheet.title_block is None
+
+
+class TestSheetExport:
+    """Tests for sheet DXF export."""
+
+    @pytest.fixture
+    def sheet_with_viewport(self):
+        """Create a sheet with a viewport for testing."""
+        sheet = Sheet(size=SheetSize.A1, number="A-101", name="Test")
+        view_result = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(5000, 0), LineStyle.default())],
+        )
+        sheet.add_viewport(view_result, position=(300, 400), scale="1:100")
+        return sheet
+
+    def test_export_creates_file(self, sheet_with_viewport, tmp_path):
+        """Test that export creates a DXF file."""
+        filepath = tmp_path / "test_sheet.dxf"
+
+        result = sheet_with_viewport.export_dxf(str(filepath))
+
+        assert result is True
+        assert filepath.exists()
+
+    def test_export_has_paperspace_layout(self, sheet_with_viewport, tmp_path):
+        """Test that exported file has paperspace layout when flat=False."""
+        import ezdxf
+
+        filepath = tmp_path / "test_sheet.dxf"
+        sheet_with_viewport.export_dxf(str(filepath), flat=False)
+
+        doc = ezdxf.readfile(str(filepath))
+        layouts = list(doc.layouts)
+
+        # Should have Model + at least one paperspace layout
+        assert len(layouts) >= 2
+        # Check our layout name exists
+        layout_names = [layout.name for layout in layouts]
+        assert "A-101 - Test" in layout_names
+
+    def test_export_empty_sheet(self, tmp_path):
+        """Test exporting sheet with no viewports."""
+        sheet = Sheet(size=SheetSize.A1, number="A-102", name="Empty")
+        filepath = tmp_path / "empty_sheet.dxf"
+
+        result = sheet.export_dxf(str(filepath))
+
+        assert result is True
+        assert filepath.exists()
+
+    def test_export_sheet_with_multiple_viewports(self, tmp_path):
+        """Test exporting sheet with multiple viewports."""
+        sheet = Sheet(size=SheetSize.ARCH_D, number="A-103")
+
+        view1 = ViewResult(lines=[Line2D(Point2D(0, 0), Point2D(3000, 0), LineStyle.default())])
+        view2 = ViewResult(lines=[Line2D(Point2D(0, 0), Point2D(2000, 2000), LineStyle.default())])
+
+        sheet.add_viewport(view1, position=(200, 300), scale="1:100")
+        sheet.add_viewport(view2, position=(500, 300), scale="1:50")
+
+        filepath = tmp_path / "multi_viewport.dxf"
+        result = sheet.export_dxf(str(filepath))
+
+        assert result is True
+        assert filepath.exists()


### PR DESCRIPTION
- Add Sheet, SheetSize, SheetViewport, TitleBlock classes for assembling views into printable DXF sheets
- Add flat sheet export mode using scale_and_translate() to position geometry on sheet coordinates (works with any DXF viewer)
- Add TagStyle.scale() for proper tag sizing on scaled sheets
- Add dimlfac field to LinearDimension2D and ChainDimension2D to display model values instead of scaled coordinates
- Add BIM-style SectionView.from_section_line() classmethod
- Update hospital example with multi-viewport sheet export
- Add comprehensive sheet tests (41 tests)

Implements #38