### PR TITLE
Add Sheet class for construction document assembly

### DIFF
--- a/examples/example_hospital_wing.py
+++ b/examples/example_hospital_wing.py
@@ -700,6 +700,7 @@ def main():
             bubble_radius=400.0,  # Larger bubbles for visibility
             text_height=200.0,
             arrow_size=300.0,
+            line_extension=800.0,  # Move bubbles further from section line ends
         ),
     )
     result.section_symbols.append(section_symbol)
@@ -717,7 +718,7 @@ def main():
         start_point=section_b_start,
         end_point=section_b_end,
         look_direction="left",  # Looking east (left when walking north to south)
-        depth=corridor_length,  # Full depth to see all doors to the east
+        depth=ROOM_WIDTH * 3,  # Show 3 rooms worth of depth
         height_range=(0, FLOOR_HEIGHT),  # Floor to ceiling
         scale=ViewScale.SCALE_1_50,
     )
@@ -736,10 +737,48 @@ def main():
             bubble_radius=400.0,
             text_height=200.0,
             arrow_size=300.0,
+            line_extension=800.0,  # Move bubbles further from section line ends
         ),
     )
     result.section_symbols.append(section_symbol_b)
     print(f"  Section symbol added: {section_symbol_b.section_id} on sheet {section_symbol_b.sheet_number}")
+
+    # Generate third section view through main corridor (perpendicular to A and B)
+    # This section runs east-west through the center of the corridor
+    print("\nGenerating section C-C through main corridor...")
+    section_c_y = CORRIDOR_WIDTH / 2  # Center of corridor
+    section_c_start = (-1000, section_c_y)  # Section line start (west, outside building)
+    section_c_end = (corridor_length + 1000, section_c_y)  # Section line end (east, outside)
+
+    section_view_c = SectionView.from_section_line(
+        name="Section C-C",
+        start_point=section_c_start,
+        end_point=section_c_end,
+        look_direction="right",  # Looking south (right when walking west to east)
+        depth=ROOM_DEPTH + CORRIDOR_WIDTH / 2,  # See south rooms from corridor center
+        height_range=(0, FLOOR_HEIGHT),  # Floor to ceiling
+        scale=ViewScale.SCALE_1_100,  # Smaller scale for long section
+    )
+    section_c_result = section_view_c.generate(spatial_index, cache)
+    print(f"  Section C elements: {section_c_result.element_count}")
+    print(f"  Section C geometry: {section_c_result.total_geometry_count}")
+
+    # Add section C symbol to floor plan
+    section_symbol_c = SectionSymbol.from_section_view(
+        section_view=section_view_c,
+        start_point=Point2D(section_c_start[0], section_c_start[1]),
+        end_point=Point2D(section_c_end[0], section_c_end[1]),
+        section_id="C",
+        sheet_number="A-103",
+        style=SectionSymbolStyle(
+            bubble_radius=400.0,
+            text_height=200.0,
+            arrow_size=300.0,
+            line_extension=800.0,  # Move bubbles further from section line ends
+        ),
+    )
+    result.section_symbols.append(section_symbol_c)
+    print(f"  Section symbol added: {section_symbol_c.section_id} on sheet {section_symbol_c.sheet_number}")
     print(f"  Floor plan now has {len(result.section_symbols)} section symbol(s)")
 
     # Export floor plan DXF (includes section symbol)
@@ -759,6 +798,11 @@ def main():
     exporter.export(section_b_result, str(section_b_dxf_path))
     print(f"  Saved: {section_b_dxf_path.name}")
 
+    # Export section C DXF (through main corridor)
+    section_c_dxf_path = output_dir / "hospital_wing_section_C.dxf"
+    exporter.export(section_c_result, str(section_c_dxf_path))
+    print(f"  Saved: {section_c_dxf_path.name}")
+
     # Create sheet with floor plan and section viewports
     print("\nCreating construction document sheet...")
     sheet = Sheet(
@@ -773,30 +817,41 @@ def main():
         ),
     )
 
-    # Add floor plan viewport (upper portion of sheet)
-    # ARCH_D is 609.6mm x 914.4mm (portrait)
-    # Floor plan is wide (~460mm at 1:100), so center it horizontally
-    # and place it in the upper 2/3 of the sheet
+    # Layout all 4 viewports on single sheet
+    # ARCH_D is 609.6mm x 914.4mm (portrait), center X = 304.8
+    # Layout:
+    #   - Floor plan at top (centered)
+    #   - Section C (corridor, horizontal) in middle (centered)
+    #   - Sections A and B side by side at bottom
+
+    # Floor plan viewport (top of sheet)
     sheet.add_viewport(
         result,
-        position=(305, 457),  # Centered on sheet
+        position=(304.8, 730),  # Centered horizontally, top
         scale=ViewScale.SCALE_1_100,
         name="Floor Plan",
     )
 
-    # Add section A viewport (lower left of sheet)
-    # Section is narrower but taller - place below the floor plan
+    # Section C viewport (middle - long corridor section)
+    sheet.add_viewport(
+        section_c_result,
+        position=(304.8, 420),  # Centered horizontally, middle
+        scale=ViewScale.SCALE_1_100,
+        name="Section C-C",
+    )
+
+    # Section A viewport (bottom left)
     sheet.add_viewport(
         section_result,
-        position=(200, 180),  # Left side, lower portion
-        scale=ViewScale.SCALE_1_50,  # Larger scale for detail
+        position=(160, 150),  # Left side, bottom
+        scale=ViewScale.SCALE_1_50,
         name="Section A-A",
     )
 
-    # Add section B viewport (lower right of sheet)
+    # Section B viewport (bottom right)
     sheet.add_viewport(
         section_b_result,
-        position=(450, 180),  # Right side, lower portion
+        position=(450, 150),  # Right side, bottom
         scale=ViewScale.SCALE_1_50,
         name="Section B-B",
     )

--- a/examples/example_hospital_wing.py
+++ b/examples/example_hospital_wing.py
@@ -40,7 +40,7 @@ from bimascode.drawing.primitives import (
 from bimascode.drawing.section_view import SectionView
 from bimascode.drawing.sheet import Sheet, SheetMetadata
 from bimascode.drawing.sheet_sizes import SheetSize
-from bimascode.drawing.tags import DoorTag, RoomTag, TagStyle
+from bimascode.drawing.tags import DoorTag, RoomTag, SectionSymbol, SectionSymbolStyle, TagStyle
 from bimascode.drawing.view_base import ViewRange, ViewScale
 from bimascode.performance.representation_cache import RepresentationCache
 from bimascode.performance.spatial_index import SpatialIndex
@@ -536,7 +536,7 @@ def add_annotations(
     depth_dim_west = LinearDimension2D(
         start=Point2D(0, south_room_y),
         end=Point2D(0, 0),  # corridor south edge
-        offset=-1500,
+        offset=1500,
         precision=0,
         style=dim_style,
     )
@@ -546,7 +546,7 @@ def add_annotations(
     corridor_dim = LinearDimension2D(
         start=Point2D(0, 0),
         end=Point2D(0, CORRIDOR_WIDTH),
-        offset=-1500,
+        offset=1500,
         precision=0,
         style=dim_style,
     )
@@ -556,7 +556,7 @@ def add_annotations(
     depth_dim_north = LinearDimension2D(
         start=Point2D(0, CORRIDOR_WIDTH),
         end=Point2D(0, north_room_y),
-        offset=-1500,
+        offset=1500,
         precision=0,
         style=dim_style,
     )
@@ -666,23 +666,20 @@ def main():
     print(f"  Door tags: {len(result.door_tags)}")
     print(f"  Room tags: {len(result.room_tags)}")
 
-    # Export DXF (standalone floor plan)
-    dxf_path = output_dir / "hospital_wing_plan.dxf"
-    exporter = DXFExporter()
-    exporter.export(result, str(dxf_path))
-    print(f"\n  Saved: {dxf_path.name}")
-
-    # Generate section view through patient rooms
-    # Section cuts perpendicular to corridor, through the middle of a patient room
+    # Generate section view through center of building
+    # Section cuts parallel to corridor (north-south line through center)
     # Using BIM-style section line: draw line on plan, specify look direction
     print("\nGenerating section view...")
-    section_x = ROOM_WIDTH / 2  # Cut through center of first room
+    section_x = corridor_length / 2  # Cut through center of building
+    section_start = (section_x, north_room_y + 1000)  # Section line start (north)
+    section_end = (section_x, south_room_y - 1000)  # Section line end (south)
+
     section_view = SectionView.from_section_line(
         name="Section A-A",
-        start_point=(section_x, south_room_y - 1000),  # Section line start (south)
-        end_point=(section_x, north_room_y + 1000),  # Section line end (north)
-        look_direction="right",  # Looking east (right when walking south to north)
-        depth=corridor_length,  # View depth to see beyond section
+        start_point=section_start,
+        end_point=section_end,
+        look_direction="right",  # Looking west (right when walking north to south)
+        depth=corridor_length / 2,  # View depth to see half the building
         height_range=(0, FLOOR_HEIGHT),  # Floor to ceiling
         scale=ViewScale.SCALE_1_50,
     )
@@ -690,10 +687,77 @@ def main():
     print(f"  Section elements: {section_result.element_count}")
     print(f"  Section geometry: {section_result.total_geometry_count}")
 
+    # Add section symbol to floor plan
+    # This marks where the section cut is located with arrows showing view direction
+    print("\nAdding section symbol to floor plan...")
+    section_symbol = SectionSymbol.from_section_view(
+        section_view=section_view,
+        start_point=Point2D(section_start[0], section_start[1]),
+        end_point=Point2D(section_end[0], section_end[1]),
+        section_id="A",
+        sheet_number="A-101",
+        style=SectionSymbolStyle(
+            bubble_radius=400.0,  # Larger bubbles for visibility
+            text_height=200.0,
+            arrow_size=300.0,
+        ),
+    )
+    result.section_symbols.append(section_symbol)
+    print(f"  Section symbol added: {section_symbol.section_id} on sheet {section_symbol.sheet_number}")
+
+    # Generate second section view through patient rooms (cuts through doors)
+    # This section runs north-south through the center of the first patient room
+    print("\nGenerating section B-B through patient rooms...")
+    section_b_x = ROOM_WIDTH / 2  # Center of first room (cuts through door)
+    section_b_start = (section_b_x, north_room_y + 1000)  # Section line start (north)
+    section_b_end = (section_b_x, south_room_y - 1000)  # Section line end (south)
+
+    section_view_b = SectionView.from_section_line(
+        name="Section B-B",
+        start_point=section_b_start,
+        end_point=section_b_end,
+        look_direction="left",  # Looking east (left when walking north to south)
+        depth=corridor_length,  # Full depth to see all doors to the east
+        height_range=(0, FLOOR_HEIGHT),  # Floor to ceiling
+        scale=ViewScale.SCALE_1_50,
+    )
+    section_b_result = section_view_b.generate(spatial_index, cache)
+    print(f"  Section B elements: {section_b_result.element_count}")
+    print(f"  Section B geometry: {section_b_result.total_geometry_count}")
+
+    # Add section B symbol to floor plan
+    section_symbol_b = SectionSymbol.from_section_view(
+        section_view=section_view_b,
+        start_point=Point2D(section_b_start[0], section_b_start[1]),
+        end_point=Point2D(section_b_end[0], section_b_end[1]),
+        section_id="B",
+        sheet_number="A-102",
+        style=SectionSymbolStyle(
+            bubble_radius=400.0,
+            text_height=200.0,
+            arrow_size=300.0,
+        ),
+    )
+    result.section_symbols.append(section_symbol_b)
+    print(f"  Section symbol added: {section_symbol_b.section_id} on sheet {section_symbol_b.sheet_number}")
+    print(f"  Floor plan now has {len(result.section_symbols)} section symbol(s)")
+
+    # Export floor plan DXF (includes section symbol)
+    print("\nExporting DXF files...")
+    exporter = DXFExporter()
+    dxf_path = output_dir / "hospital_wing_plan.dxf"
+    exporter.export(result, str(dxf_path))
+    print(f"  Saved: {dxf_path.name}")
+
     # Export section DXF (standalone)
-    section_dxf_path = output_dir / "hospital_wing_section.dxf"
+    section_dxf_path = output_dir / "hospital_wing_section_A.dxf"
     exporter.export(section_result, str(section_dxf_path))
     print(f"  Saved: {section_dxf_path.name}")
+
+    # Export section B DXF (through patient rooms with doors)
+    section_b_dxf_path = output_dir / "hospital_wing_section_B.dxf"
+    exporter.export(section_b_result, str(section_b_dxf_path))
+    print(f"  Saved: {section_b_dxf_path.name}")
 
     # Create sheet with floor plan and section viewports
     print("\nCreating construction document sheet...")
@@ -720,13 +784,21 @@ def main():
         name="Floor Plan",
     )
 
-    # Add section viewport (lower portion of sheet)
+    # Add section A viewport (lower left of sheet)
     # Section is narrower but taller - place below the floor plan
     sheet.add_viewport(
         section_result,
-        position=(305, 180),  # Centered horizontally, lower portion
+        position=(200, 180),  # Left side, lower portion
         scale=ViewScale.SCALE_1_50,  # Larger scale for detail
         name="Section A-A",
+    )
+
+    # Add section B viewport (lower right of sheet)
+    sheet.add_viewport(
+        section_b_result,
+        position=(450, 180),  # Right side, lower portion
+        scale=ViewScale.SCALE_1_50,
+        name="Section B-B",
     )
 
     print(f"  Sheet: {sheet.number} - {sheet.name}")

--- a/src/bimascode/drawing/__init__.py
+++ b/src/bimascode/drawing/__init__.py
@@ -43,12 +43,6 @@ from bimascode.drawing.primitives import (
     ViewResult,
 )
 
-# Sheets
-from bimascode.drawing.sheet import Sheet, SheetMetadata
-from bimascode.drawing.sheet_sizes import SheetSize
-from bimascode.drawing.title_block import TitleBlock
-from bimascode.drawing.viewport import SheetViewport
-
 # Protocols
 from bimascode.drawing.protocols import (
     Drawable2D,
@@ -56,6 +50,14 @@ from bimascode.drawing.protocols import (
     HasGeometry,
     Linework2D,
 )
+
+# Utilities
+from bimascode.drawing.section_cutter import SectionCutter, get_section_cutter
+from bimascode.drawing.section_view import SectionView
+
+# Sheets
+from bimascode.drawing.sheet import Sheet, SheetMetadata
+from bimascode.drawing.sheet_sizes import SheetSize
 
 # Symbology
 from bimascode.drawing.symbology import (
@@ -65,12 +67,18 @@ from bimascode.drawing.symbology import (
     get_default_symbology,
 )
 
-# Utilities
-from bimascode.drawing.section_cutter import SectionCutter, get_section_cutter
-from bimascode.drawing.section_view import SectionView
-
-# Tags
-from bimascode.drawing.tags import DoorTag, RoomTag, Tag2D, TagShape, TagStyle, WindowTag
+# Tags and Section Symbols
+from bimascode.drawing.tags import (
+    DoorTag,
+    RoomTag,
+    SectionSymbol,
+    SectionSymbolStyle,
+    Tag2D,
+    TagShape,
+    TagStyle,
+    WindowTag,
+)
+from bimascode.drawing.title_block import TitleBlock
 
 # View base classes
 from bimascode.drawing.view_base import (
@@ -87,6 +95,7 @@ from bimascode.drawing.view_templates import (
     ViewTemplate,
     ViewVisibilitySettings,
 )
+from bimascode.drawing.viewport import SheetViewport
 
 __all__ = [
     # Primitives
@@ -147,11 +156,13 @@ __all__ = [
     "DXFExporter",
     "DXFSheetExporter",
     "get_dxf_exporter",
-    # Tags
+    # Tags and Section Symbols
     "DoorTag",
     "WindowTag",
     "RoomTag",
     "TagStyle",
     "TagShape",
     "Tag2D",
+    "SectionSymbol",
+    "SectionSymbolStyle",
 ]

--- a/src/bimascode/drawing/dxf_exporter.py
+++ b/src/bimascode/drawing/dxf_exporter.py
@@ -1260,6 +1260,79 @@ class DXFSheetExporter:
             doc, layout, view_result.section_symbols, scale
         )
 
+    def _add_viewport_label(
+        self,
+        msp,
+        viewport,
+        scaled_view: ViewResult,
+    ) -> None:
+        """Add a label below a viewport with view name and scale.
+
+        The label consists of:
+        - View name (e.g., "Section A-A" or "Floor Plan")
+        - Underline
+        - Scale notation (e.g., "Scale: 1:50")
+
+        Args:
+            msp: Modelspace to add label to
+            viewport: SheetViewport being labeled
+            scaled_view: The scaled/translated view result (for bounds)
+        """
+        # Get the view name - prefer viewport name, fall back to view_result name
+        view_name = viewport.name or viewport.view_result.view_name
+        if not view_name:
+            return  # No name to display
+
+        # Get bounds of the scaled view content
+        bounds = scaled_view.get_bounds()
+        if bounds is None:
+            return
+
+        # Position label centered below the view
+        center_x = (bounds[0] + bounds[2]) / 2
+        view_bottom = bounds[1]
+
+        # Label sizing - proportional to sheet (typical sheet text is 2.5-3.5mm)
+        text_height = 3.0  # mm on sheet
+        line_spacing = text_height * 1.5
+        label_offset = 5.0  # Gap between view and label
+
+        # View name position (centered, below view)
+        name_y = view_bottom - label_offset - text_height
+
+        # Add view name text
+        msp.add_mtext(
+            view_name,
+            dxfattribs={
+                "layer": Layer.ANNOTATION,
+                "char_height": text_height,
+                "attachment_point": 8,  # BOTTOM_CENTER
+            },
+        ).set_location(insert=(center_x, name_y))
+
+        # Add underline below the name
+        # Estimate text width (approximate: 0.6 * height * num_chars)
+        text_width = len(view_name) * text_height * 0.6
+        underline_y = name_y - text_height * 0.3
+        msp.add_line(
+            start=(center_x - text_width / 2, underline_y),
+            end=(center_x + text_width / 2, underline_y),
+            dxfattribs={"layer": Layer.ANNOTATION},
+        )
+
+        # Add scale notation below the underline
+        scale_text = f"Scale: {viewport.scale.name}"
+        scale_y = underline_y - line_spacing
+
+        msp.add_mtext(
+            scale_text,
+            dxfattribs={
+                "layer": Layer.ANNOTATION,
+                "char_height": text_height * 0.8,  # Slightly smaller
+                "attachment_point": 8,  # BOTTOM_CENTER
+            },
+        ).set_location(insert=(center_x, scale_y))
+
     def export_sheet_flat(
         self,
         sheet: Sheet,
@@ -1314,6 +1387,9 @@ class DXFSheetExporter:
 
             # Export to modelspace
             self._export_view_result_to_layout(doc, msp, scaled_view, scale=1.0)
+
+            # Add viewport label below the view
+            self._add_viewport_label(msp, viewport, scaled_view)
 
         # Export title block to modelspace (if present)
         if sheet.title_block and sheet.title_block.has_geometry():

--- a/src/bimascode/drawing/dxf_exporter.py
+++ b/src/bimascode/drawing/dxf_exporter.py
@@ -21,7 +21,7 @@ from bimascode.drawing.primitives import (
     TextNote2D,
     ViewResult,
 )
-from bimascode.drawing.tags import DoorTag, RoomTag, TagShape, WindowTag
+from bimascode.drawing.tags import DoorTag, RoomTag, SectionSymbol, TagShape, WindowTag
 
 if TYPE_CHECKING:
     from bimascode.drawing.sheet import Sheet
@@ -124,6 +124,7 @@ class DXFExporter:
         self._export_door_tags(doc, msp, view_result.door_tags, scale)
         self._export_window_tags(doc, msp, view_result.window_tags, scale)
         self._export_room_tags(doc, msp, view_result.room_tags, scale)
+        self._export_section_symbols(doc, msp, view_result.section_symbols, scale)
 
         # Save file
         doc.saveas(filepath)
@@ -154,6 +155,8 @@ class DXFExporter:
             layers.add(tag.layer)
         for tag in view_result.room_tags:
             layers.add(tag.layer)
+        for symbol in view_result.section_symbols:
+            layers.add(symbol.layer)
 
         # Create layers with standard AIA colors
         layer_colors = {
@@ -703,6 +706,202 @@ class DXFExporter:
                 }
             )
 
+    def _create_section_symbol_block(
+        self,
+        doc,
+        block_name: str,
+        bubble_radius: float,
+        text_height: float,
+        arrow_size: float,
+    ) -> None:
+        """Create a section symbol bubble block definition if it doesn't exist.
+
+        Creates a circular reference bubble with two attribute definitions:
+        - SECTION_ID: The section identifier (e.g., "A")
+        - SHEET_NUMBER: The destination sheet number (e.g., "A2")
+
+        The bubble is drawn at the origin with the specified radius.
+
+        Args:
+            doc: DXF document
+            block_name: Name for the block
+            bubble_radius: Radius of the bubble circle
+            text_height: Height of the text
+            arrow_size: Size of arrow (used for spacing calculations)
+        """
+        if block_name in doc.blocks:
+            return
+
+        block = doc.blocks.new(name=block_name)
+
+        # Draw the bubble circle
+        block.add_circle(center=(0, 0), radius=bubble_radius)
+
+        # Add attribute definition for section ID (upper half)
+        line_spacing = text_height * 0.8
+        block.add_attdef(
+            tag="SECTION_ID",
+            insert=(0, line_spacing / 2),
+            dxfattribs={
+                "height": text_height,
+                "halign": 4,  # Middle center
+                "valign": 2,  # Middle
+            },
+        )
+
+        # Add attribute definition for sheet number (lower half)
+        block.add_attdef(
+            tag="SHEET_NUMBER",
+            insert=(0, -line_spacing / 2),
+            dxfattribs={
+                "height": text_height * 0.8,  # Slightly smaller
+                "halign": 4,  # Middle center
+                "valign": 2,  # Middle
+            },
+        )
+
+        # Add horizontal divider line in the bubble
+        block.add_line(
+            start=(-bubble_radius * 0.7, 0),
+            end=(bubble_radius * 0.7, 0),
+        )
+
+    def _export_section_symbols(
+        self,
+        doc,
+        msp,
+        symbols: list[SectionSymbol],
+        scale: float,
+    ) -> None:
+        """Export SectionSymbol objects to DXF.
+
+        Each section symbol consists of:
+        1. A cut line between start and end points
+        2. Arrow heads pointing in the view direction
+        3. Reference bubbles (BLOCK references) at each end
+
+        Args:
+            doc: DXF document
+            msp: Modelspace or layout to export to
+            symbols: List of SectionSymbol objects
+            scale: Scale factor
+        """
+        for symbol in symbols:
+            # Create block definition for bubbles if needed
+            self._create_section_symbol_block(
+                doc,
+                symbol.block_name,
+                symbol.style.bubble_radius * scale,
+                symbol.style.text_height * scale,
+                symbol.style.arrow_size * scale,
+            )
+
+            # Draw the section cut line
+            start = (symbol.start_point.x * scale, symbol.start_point.y * scale)
+            end = (symbol.end_point.x * scale, symbol.end_point.y * scale)
+
+            msp.add_line(
+                start=start,
+                end=end,
+                dxfattribs={
+                    "layer": symbol.layer,
+                    "lineweight": DXF_LINEWEIGHT_MAP.get(LineWeight.MEDIUM, 35),
+                },
+            )
+
+            # Draw arrow heads if enabled
+            if symbol.style.show_arrows:
+                arrow_angle = symbol.arrow_angle
+                arrow_size = symbol.style.arrow_size * scale
+
+                # Arrow at start point
+                self._draw_section_arrow(
+                    msp,
+                    (symbol.start_point.x * scale, symbol.start_point.y * scale),
+                    arrow_angle,
+                    arrow_size,
+                    symbol.layer,
+                )
+
+                # Arrow at end point
+                self._draw_section_arrow(
+                    msp,
+                    (symbol.end_point.x * scale, symbol.end_point.y * scale),
+                    arrow_angle,
+                    arrow_size,
+                    symbol.layer,
+                )
+
+            # Draw reference bubbles if enabled
+            if symbol.style.show_bubbles:
+                # Start bubble
+                start_bubble = symbol.get_start_bubble_center()
+                block_ref = msp.add_blockref(
+                    symbol.block_name,
+                    insert=(start_bubble.x * scale, start_bubble.y * scale),
+                    dxfattribs={"layer": symbol.layer},
+                )
+                block_ref.add_auto_attribs(
+                    {
+                        "SECTION_ID": symbol.start_label,
+                        "SHEET_NUMBER": symbol.start_sheet,
+                    }
+                )
+
+                # End bubble
+                end_bubble = symbol.get_end_bubble_center()
+                block_ref = msp.add_blockref(
+                    symbol.block_name,
+                    insert=(end_bubble.x * scale, end_bubble.y * scale),
+                    dxfattribs={"layer": symbol.layer},
+                )
+                block_ref.add_auto_attribs(
+                    {
+                        "SECTION_ID": symbol.end_label,
+                        "SHEET_NUMBER": symbol.end_sheet,
+                    }
+                )
+
+    def _draw_section_arrow(
+        self,
+        msp,
+        point: tuple[float, float],
+        angle: float,
+        size: float,
+        layer: str,
+    ) -> None:
+        """Draw a section arrow head at the specified point.
+
+        The arrow is a filled triangle pointing in the specified direction.
+
+        Args:
+            msp: Modelspace or layout to draw on
+            point: Arrow tip location (x, y)
+            angle: Arrow direction in radians
+            size: Arrow size (length)
+            layer: CAD layer name
+        """
+        # Arrow head as a solid triangle
+        # Calculate the three points of the triangle
+        tip_x, tip_y = point
+
+        # Back corners of the arrow
+        back_angle1 = angle + math.pi + math.pi / 6  # 150 degrees from tip direction
+        back_angle2 = angle + math.pi - math.pi / 6  # 210 degrees from tip direction
+
+        back1_x = tip_x + size * math.cos(back_angle1)
+        back1_y = tip_y + size * math.sin(back_angle1)
+        back2_x = tip_x + size * math.cos(back_angle2)
+        back2_y = tip_y + size * math.sin(back_angle2)
+
+        # Draw as solid hatch (filled triangle)
+        hatch = msp.add_hatch(color=7, dxfattribs={"layer": layer})
+        hatch.set_solid_fill()
+        hatch.paths.add_polyline_path(
+            [(tip_x, tip_y), (back1_x, back1_y), (back2_x, back2_y)],
+            is_closed=True,
+        )
+
     def export_multiple(
         self,
         views: list[tuple[ViewResult, tuple[float, float]]],
@@ -751,6 +950,8 @@ class DXFExporter:
                 all_layers.add(tag.layer)
             for tag in view_result.room_tags:
                 all_layers.add(tag.layer)
+            for symbol in view_result.section_symbols:
+                all_layers.add(symbol.layer)
 
         # Setup layers and line types
         for layer_name in all_layers:
@@ -773,6 +974,7 @@ class DXFExporter:
             self._export_door_tags(doc, msp, translated.door_tags, scale)
             self._export_window_tags(doc, msp, translated.window_tags, scale)
             self._export_room_tags(doc, msp, translated.room_tags, scale)
+            self._export_section_symbols(doc, msp, translated.section_symbols, scale)
 
         # Save file
         doc.saveas(filepath)
@@ -1030,6 +1232,8 @@ class DXFSheetExporter:
             layers.add(tag.layer)
         for tag in view_result.room_tags:
             layers.add(tag.layer)
+        for symbol in view_result.section_symbols:
+            layers.add(symbol.layer)
 
     def _export_view_result_to_layout(
         self, doc, layout, view_result: ViewResult, scale: float
@@ -1052,6 +1256,9 @@ class DXFSheetExporter:
         self._model_exporter._export_door_tags(doc, layout, view_result.door_tags, scale)
         self._model_exporter._export_window_tags(doc, layout, view_result.window_tags, scale)
         self._model_exporter._export_room_tags(doc, layout, view_result.room_tags, scale)
+        self._model_exporter._export_section_symbols(
+            doc, layout, view_result.section_symbols, scale
+        )
 
     def export_sheet_flat(
         self,
@@ -1103,27 +1310,21 @@ class DXFSheetExporter:
             offset_y = viewport.position.y - model_center_y * scale
 
             # Scale and translate the view content
-            scaled_view = viewport.view_result.scale_and_translate(
-                scale, offset_x, offset_y
-            )
+            scaled_view = viewport.view_result.scale_and_translate(scale, offset_x, offset_y)
 
             # Export to modelspace
             self._export_view_result_to_layout(doc, msp, scaled_view, scale=1.0)
 
         # Export title block to modelspace (if present)
         if sheet.title_block and sheet.title_block.has_geometry():
-            self._export_view_result_to_layout(
-                doc, msp, sheet.title_block.geometry, scale=1.0
-            )
+            self._export_view_result_to_layout(doc, msp, sheet.title_block.geometry, scale=1.0)
 
         # Export sheet annotations to modelspace
         if sheet.annotations.total_geometry_count > 0:
             self._export_view_result_to_layout(doc, msp, sheet.annotations, scale=1.0)
 
         # Draw sheet border (optional - helps visualize sheet bounds)
-        msp.add_line(
-            (0, 0), (sheet.size.width, 0), dxfattribs={"layer": "0", "color": 8}
-        )
+        msp.add_line((0, 0), (sheet.size.width, 0), dxfattribs={"layer": "0", "color": 8})
         msp.add_line(
             (sheet.size.width, 0),
             (sheet.size.width, sheet.size.height),
@@ -1134,9 +1335,7 @@ class DXFSheetExporter:
             (0, sheet.size.height),
             dxfattribs={"layer": "0", "color": 8},
         )
-        msp.add_line(
-            (0, sheet.size.height), (0, 0), dxfattribs={"layer": "0", "color": 8}
-        )
+        msp.add_line((0, sheet.size.height), (0, 0), dxfattribs={"layer": "0", "color": 8})
 
         # Save file
         doc.saveas(filepath)

--- a/src/bimascode/drawing/primitives.py
+++ b/src/bimascode/drawing/primitives.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Union
 from bimascode.drawing.line_styles import LineStyle
 
 if TYPE_CHECKING:
-    from bimascode.drawing.tags import DoorTag, RoomTag, WindowTag
+    from bimascode.drawing.tags import DoorTag, RoomTag, SectionSymbol, WindowTag
 
 
 @dataclass(frozen=True)
@@ -521,9 +521,7 @@ class LinearDimension2D:
             layer=self.layer,
         )
 
-    def scale_and_translate(
-        self, scale: float, dx: float, dy: float
-    ) -> LinearDimension2D:
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> LinearDimension2D:
         """Return a scaled and translated copy.
 
         The dimlfac is set to maintain correct dimension text display.
@@ -628,9 +626,7 @@ class ChainDimension2D:
             layer=self.layer,
         )
 
-    def scale_and_translate(
-        self, scale: float, dx: float, dy: float
-    ) -> ChainDimension2D:
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> ChainDimension2D:
         """Return a scaled and translated copy.
 
         The dimlfac is set to maintain correct dimension text display.
@@ -690,9 +686,10 @@ class ViewResult:
     dimensions: list[LinearDimension2D] = field(default_factory=list)
     chain_dimensions: list[ChainDimension2D] = field(default_factory=list)
     text_notes: list[TextNote2D] = field(default_factory=list)
-    door_tags: list["DoorTag"] = field(default_factory=list)
-    window_tags: list["WindowTag"] = field(default_factory=list)
-    room_tags: list["RoomTag"] = field(default_factory=list)
+    door_tags: list[DoorTag] = field(default_factory=list)
+    window_tags: list[WindowTag] = field(default_factory=list)
+    room_tags: list[RoomTag] = field(default_factory=list)
+    section_symbols: list[SectionSymbol] = field(default_factory=list)
     view_name: str = ""
     generation_time: float = 0.0
     element_count: int = 0
@@ -712,6 +709,7 @@ class ViewResult:
             + len(self.door_tags)
             + len(self.window_tags)
             + len(self.room_tags)
+            + len(self.section_symbols)
         )
 
     @property
@@ -739,6 +737,7 @@ class ViewResult:
         self.door_tags.extend(other.door_tags)
         self.window_tags.extend(other.window_tags)
         self.room_tags.extend(other.room_tags)
+        self.section_symbols.extend(other.section_symbols)
         self.element_count += other.element_count
         self.cache_hits += other.cache_hits
 
@@ -755,15 +754,14 @@ class ViewResult:
             door_tags=[t.translate(dx, dy) for t in self.door_tags],
             window_tags=[t.translate(dx, dy) for t in self.window_tags],
             room_tags=[t.translate(dx, dy) for t in self.room_tags],
+            section_symbols=[s.translate(dx, dy) for s in self.section_symbols],
             view_name=self.view_name,
             generation_time=self.generation_time,
             element_count=self.element_count,
             cache_hits=self.cache_hits,
         )
 
-    def scale_and_translate(
-        self, scale: float, dx: float, dy: float
-    ) -> ViewResult:
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> ViewResult:
         """Return a scaled and translated copy of all geometry.
 
         Applies scaling first (from origin), then translation.
@@ -779,28 +777,15 @@ class ViewResult:
         return ViewResult(
             lines=[line.scale_and_translate(scale, dx, dy) for line in self.lines],
             arcs=[arc.scale_and_translate(scale, dx, dy) for arc in self.arcs],
-            polylines=[
-                pl.scale_and_translate(scale, dx, dy) for pl in self.polylines
-            ],
+            polylines=[pl.scale_and_translate(scale, dx, dy) for pl in self.polylines],
             hatches=[h.scale_and_translate(scale, dx, dy) for h in self.hatches],
-            dimensions=[
-                d.scale_and_translate(scale, dx, dy) for d in self.dimensions
-            ],
-            chain_dimensions=[
-                c.scale_and_translate(scale, dx, dy) for c in self.chain_dimensions
-            ],
-            text_notes=[
-                t.scale_and_translate(scale, dx, dy) for t in self.text_notes
-            ],
-            door_tags=[
-                t.scale_and_translate(scale, dx, dy) for t in self.door_tags
-            ],
-            window_tags=[
-                t.scale_and_translate(scale, dx, dy) for t in self.window_tags
-            ],
-            room_tags=[
-                t.scale_and_translate(scale, dx, dy) for t in self.room_tags
-            ],
+            dimensions=[d.scale_and_translate(scale, dx, dy) for d in self.dimensions],
+            chain_dimensions=[c.scale_and_translate(scale, dx, dy) for c in self.chain_dimensions],
+            text_notes=[t.scale_and_translate(scale, dx, dy) for t in self.text_notes],
+            door_tags=[t.scale_and_translate(scale, dx, dy) for t in self.door_tags],
+            window_tags=[t.scale_and_translate(scale, dx, dy) for t in self.window_tags],
+            room_tags=[t.scale_and_translate(scale, dx, dy) for t in self.room_tags],
+            section_symbols=[s.scale_and_translate(scale, dx, dy) for s in self.section_symbols],
             view_name=self.view_name,
             generation_time=self.generation_time,
             element_count=self.element_count,
@@ -871,6 +856,13 @@ class ViewResult:
         for tag in self.room_tags:
             # Include tag position
             all_points.append(tag.insertion_point)
+
+        for symbol in self.section_symbols:
+            # Include section symbol endpoints and bubble centers
+            all_points.append(symbol.start_point)
+            all_points.append(symbol.end_point)
+            all_points.append(symbol.get_start_bubble_center())
+            all_points.append(symbol.get_end_bubble_center())
 
         if not all_points:
             return None

--- a/src/bimascode/drawing/section_cutter.py
+++ b/src/bimascode/drawing/section_cutter.py
@@ -283,8 +283,31 @@ class SectionCutter:
         result: list[Line2D | Arc2D] = []
 
         # For vertical sections, we need to project to 2D
-        # The section result is in 3D; we project to the section plane
-        # For simplicity, we use X and Z as the 2D coordinates
+        # The section result is in 3D; we project based on plane orientation
+        # Z is always vertical in the section
+        # Horizontal axis depends on which way the plane faces:
+        # - If normal is primarily in X direction: use Y for horizontal
+        # - If normal is primarily in Y direction: use X for horizontal
+        #
+        # The horizontal axis sign must match HLR convention:
+        # HLR x_axis = view_direction × up = normal × (0,0,1)
+        # For east view (1,0,0): x_axis = (0,-1,0), so HLR X = -world_Y
+        # For west view (-1,0,0): x_axis = (0,1,0), so HLR X = +world_Y
+        # For north view (0,1,0): x_axis = (1,0,0), so HLR X = +world_X
+        # For south view (0,-1,0): x_axis = (-1,0,0), so HLR X = -world_X
+        nx, ny, nz = plane_normal
+        use_y_for_horizontal = abs(nx) > abs(ny)
+
+        # Determine sign for horizontal axis to match HLR convention
+        # HLR x_axis = view × up, where view = plane_normal, up = (0,0,1)
+        # Cross product (nx,ny,0) × (0,0,1) = (ny, -nx, 0)
+        # So HLR X-axis direction is (ny, -nx, 0)
+        # If use_y_for_horizontal: HLR X ~ -nx * world_Y (sign is -nx)
+        # If use_x_for_horizontal: HLR X ~ ny * world_X (sign is ny)
+        if use_y_for_horizontal:
+            h_sign = -1 if nx > 0 else 1  # -nx sign
+        else:
+            h_sign = 1 if ny > 0 else -1  # ny sign
 
         explorer = TopExp_Explorer(result_shape, TopAbs_EDGE)
 
@@ -302,19 +325,31 @@ class SectionCutter:
                     p1 = curve.Value(curve.FirstParameter())
                     p2 = curve.Value(curve.LastParameter())
 
-                    # Project to section plane (use distance along plane)
-                    # For now, use simple X, Z projection
-                    result.append(
-                        Line2D(
-                            start=Point2D(p1.X(), p1.Z()),
-                            end=Point2D(p2.X(), p2.Z()),
-                            style=style,
-                            layer=layer,
+                    # Project to section plane based on orientation
+                    # Apply sign to match HLR coordinate system
+                    if use_y_for_horizontal:
+                        result.append(
+                            Line2D(
+                                start=Point2D(h_sign * p1.Y(), p1.Z()),
+                                end=Point2D(h_sign * p2.Y(), p2.Z()),
+                                style=style,
+                                layer=layer,
+                            )
                         )
-                    )
+                    else:
+                        result.append(
+                            Line2D(
+                                start=Point2D(h_sign * p1.X(), p1.Z()),
+                                end=Point2D(h_sign * p2.X(), p2.Z()),
+                                style=style,
+                                layer=layer,
+                            )
+                        )
                 else:
                     # Tessellate and project
-                    lines = self._tessellate_curve_vertical(curve, style, layer)
+                    lines = self._tessellate_curve_vertical(
+                        curve, style, layer, use_y_for_horizontal, h_sign
+                    )
                     result.extend(lines)
 
             except Exception:
@@ -327,9 +362,20 @@ class SectionCutter:
         curve,
         style: LineStyle,
         layer: str,
+        use_y_for_horizontal: bool = False,
+        h_sign: float = 1.0,
         num_segments: int = 32,
     ) -> list[Line2D]:
-        """Tessellate a curve for vertical sections (X, Z projection)."""
+        """Tessellate a curve for vertical sections.
+
+        Args:
+            curve: BRepAdaptor_Curve to tessellate
+            style: Line style
+            layer: Layer name
+            use_y_for_horizontal: If True, use Y for horizontal axis; else use X
+            h_sign: Sign multiplier for horizontal axis to match HLR convention
+            num_segments: Number of segments for tessellation
+        """
         result = []
 
         first = curve.FirstParameter()
@@ -340,7 +386,10 @@ class SectionCutter:
         for i in range(num_segments + 1):
             param = first + i * step
             pnt = curve.Value(param)
-            current = Point2D(pnt.X(), pnt.Z())
+            if use_y_for_horizontal:
+                current = Point2D(h_sign * pnt.Y(), pnt.Z())
+            else:
+                current = Point2D(h_sign * pnt.X(), pnt.Z())
 
             if prev_point is not None:
                 result.append(Line2D(start=prev_point, end=current, style=style, layer=layer))

--- a/src/bimascode/drawing/section_view.py
+++ b/src/bimascode/drawing/section_view.py
@@ -110,7 +110,7 @@ class SectionView(ViewBase):
         crop_region: ViewCropRegion | None = None,
         template=None,
         show_hidden_lines: bool = True,
-    ) -> "SectionView":
+    ) -> SectionView:
         """Create a section view from a section line on plan.
 
         This is the BIM-like way to define sections: draw a line on plan

--- a/src/bimascode/drawing/tags.py
+++ b/src/bimascode/drawing/tags.py
@@ -1,4 +1,4 @@
-"""Tag annotations for doors and windows in 2D drawings.
+"""Tag annotations for doors, windows, rooms, and section symbols in 2D drawings.
 
 This module provides tag classes that display element marks at their locations,
 with support for DXF BLOCK + ATTRIB export.
@@ -6,6 +6,7 @@ with support for DXF BLOCK + ATTRIB export.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -16,6 +17,7 @@ from bimascode.drawing.primitives import Point2D
 if TYPE_CHECKING:
     from bimascode.architecture.door import Door
     from bimascode.architecture.window import Window
+    from bimascode.drawing.section_view import SectionView
     from bimascode.spatial.room import Room
 
 
@@ -398,5 +400,287 @@ class RoomTag:
         )
 
 
+@dataclass(frozen=True)
+class SectionSymbolStyle:
+    """Style configuration for section symbols.
+
+    A section symbol marks the location of a section cut on a plan view,
+    consisting of a cut line with arrow heads and reference bubbles at each end.
+
+    Attributes:
+        bubble_radius: Radius of reference bubbles at line ends (mm)
+        text_height: Height of the text in bubbles (mm)
+        arrow_size: Size of arrow heads (mm)
+        line_extension: Extension of cut line beyond bubbles (mm)
+        show_arrows: Whether to show arrow heads
+        show_bubbles: Whether to show reference bubbles
+        layer: CAD layer name for the symbol
+    """
+
+    bubble_radius: float = 200.0
+    text_height: float = 120.0
+    arrow_size: float = 150.0
+    line_extension: float = 100.0
+    show_arrows: bool = True
+    show_bubbles: bool = True
+    layer: str = Layer.SYMBOL
+
+    def scale(self, factor: float) -> SectionSymbolStyle:
+        """Return a scaled copy of this style.
+
+        Args:
+            factor: Scale factor to apply
+
+        Returns:
+            New SectionSymbolStyle with scaled dimensions
+        """
+        return SectionSymbolStyle(
+            bubble_radius=self.bubble_radius * factor,
+            text_height=self.text_height * factor,
+            arrow_size=self.arrow_size * factor,
+            line_extension=self.line_extension * factor,
+            show_arrows=self.show_arrows,
+            show_bubbles=self.show_bubbles,
+            layer=self.layer,
+        )
+
+    @classmethod
+    def default(cls) -> SectionSymbolStyle:
+        """Default style for section symbols."""
+        return cls()
+
+
+@dataclass(frozen=True)
+class SectionSymbol:
+    """Symbol marking a section cut on a plan view.
+
+    Displays a section cut line with arrow heads indicating view direction
+    and circular reference bubbles at each end containing section/sheet numbers.
+    Exports to DXF as BLOCK references with ATTRIB.
+
+    The symbol consists of:
+    - A cut line between start_point and end_point
+    - Arrow heads pointing in the view direction
+    - Reference bubbles (circles) at each end with identifiers
+
+    Attributes:
+        start_point: Start point of cut line on plan (mm)
+        end_point: End point of cut line on plan (mm)
+        section_id: Section identifier (e.g., "A", "1")
+        sheet_number: Destination sheet number (e.g., "A2", "S-101")
+        look_direction: Direction the view looks ("left" or "right" of line)
+        section_view: Optional reference to the SectionView being marked
+        style: Symbol style configuration
+        rotation: Symbol rotation in degrees (0 = auto from line direction)
+
+    Example:
+        >>> symbol = SectionSymbol(
+        ...     start_point=Point2D(5000, 0),
+        ...     end_point=Point2D(5000, 10000),
+        ...     section_id="A",
+        ...     sheet_number="A2",
+        ...     look_direction="right",
+        ... )
+    """
+
+    start_point: Point2D
+    end_point: Point2D
+    section_id: str = "A"
+    sheet_number: str = ""
+    look_direction: str = "right"  # "left" or "right" of line direction
+    section_view: SectionView | None = None
+    style: SectionSymbolStyle = field(default_factory=SectionSymbolStyle.default)
+    rotation: float = 0.0
+
+    @property
+    def line_angle(self) -> float:
+        """Get the angle of the section line in radians."""
+        dx = self.end_point.x - self.start_point.x
+        dy = self.end_point.y - self.start_point.y
+        return math.atan2(dy, dx)
+
+    @property
+    def line_length(self) -> float:
+        """Get the length of the section line."""
+        return self.start_point.distance_to(self.end_point)
+
+    @property
+    def arrow_angle(self) -> float:
+        """Get the arrow direction angle in radians.
+
+        Arrow points perpendicular to the line in the look direction.
+        """
+        line_angle = self.line_angle
+        if self.look_direction == "right":
+            # Clockwise perpendicular
+            return line_angle - math.pi / 2
+        else:
+            # Counter-clockwise perpendicular
+            return line_angle + math.pi / 2
+
+    @property
+    def midpoint(self) -> Point2D:
+        """Get the midpoint of the section line."""
+        return Point2D(
+            (self.start_point.x + self.end_point.x) / 2,
+            (self.start_point.y + self.end_point.y) / 2,
+        )
+
+    @property
+    def start_label(self) -> str:
+        """Get the label text for the start bubble."""
+        return self.section_id
+
+    @property
+    def end_label(self) -> str:
+        """Get the label text for the end bubble."""
+        return self.section_id
+
+    @property
+    def start_sheet(self) -> str:
+        """Get the sheet number text for the start bubble."""
+        return self.sheet_number
+
+    @property
+    def end_sheet(self) -> str:
+        """Get the sheet number text for the end bubble."""
+        return self.sheet_number
+
+    @property
+    def layer(self) -> str:
+        """Get the layer for this symbol."""
+        return self.style.layer
+
+    @property
+    def block_name(self) -> str:
+        """Get the DXF block name for this symbol type.
+
+        Includes style parameters in the name to ensure unique
+        block definitions for different configurations.
+        """
+        return (
+            f"SECTION_SYMBOL_{int(self.style.bubble_radius)}_"
+            f"{int(self.style.text_height)}_{int(self.style.arrow_size)}"
+        )
+
+    def get_start_bubble_center(self) -> Point2D:
+        """Get the center point of the start reference bubble.
+
+        The bubble is offset from the line endpoint by the bubble radius.
+        """
+        angle = self.line_angle + math.pi  # Opposite direction from line
+        offset = self.style.bubble_radius + self.style.line_extension
+        return Point2D(
+            self.start_point.x + offset * math.cos(angle),
+            self.start_point.y + offset * math.sin(angle),
+        )
+
+    def get_end_bubble_center(self) -> Point2D:
+        """Get the center point of the end reference bubble.
+
+        The bubble is offset from the line endpoint by the bubble radius.
+        """
+        angle = self.line_angle  # Same direction as line
+        offset = self.style.bubble_radius + self.style.line_extension
+        return Point2D(
+            self.end_point.x + offset * math.cos(angle),
+            self.end_point.y + offset * math.sin(angle),
+        )
+
+    def translate(self, dx: float, dy: float) -> SectionSymbol:
+        """Return a translated copy of this symbol."""
+        return SectionSymbol(
+            start_point=self.start_point.translate(dx, dy),
+            end_point=self.end_point.translate(dx, dy),
+            section_id=self.section_id,
+            sheet_number=self.sheet_number,
+            look_direction=self.look_direction,
+            section_view=self.section_view,
+            style=self.style,
+            rotation=self.rotation,
+        )
+
+    def scale_and_translate(self, scale: float, dx: float, dy: float) -> SectionSymbol:
+        """Return a scaled and translated copy of this symbol."""
+        return SectionSymbol(
+            start_point=self.start_point.scale_and_translate(scale, dx, dy),
+            end_point=self.end_point.scale_and_translate(scale, dx, dy),
+            section_id=self.section_id,
+            sheet_number=self.sheet_number,
+            look_direction=self.look_direction,
+            section_view=self.section_view,
+            style=self.style.scale(scale),
+            rotation=self.rotation,
+        )
+
+    @classmethod
+    def from_section_view(
+        cls,
+        section_view: SectionView,
+        start_point: Point2D,
+        end_point: Point2D,
+        section_id: str = "A",
+        sheet_number: str = "",
+        style: SectionSymbolStyle | None = None,
+    ) -> SectionSymbol:
+        """Create a section symbol from a SectionView.
+
+        Automatically determines the look direction from the section view's
+        plane normal.
+
+        Args:
+            section_view: The SectionView being marked
+            start_point: Start point of cut line on plan
+            end_point: End point of cut line on plan
+            section_id: Section identifier (e.g., "A", "1")
+            sheet_number: Destination sheet number
+            style: Optional style override
+
+        Returns:
+            SectionSymbol configured for the section view
+
+        Example:
+            >>> section = SectionView.from_section_line(
+            ...     "Section A-A",
+            ...     start_point=(5000, 0),
+            ...     end_point=(5000, 10000),
+            ...     look_direction="right",
+            ... )
+            >>> symbol = SectionSymbol.from_section_view(
+            ...     section,
+            ...     Point2D(5000, 0),
+            ...     Point2D(5000, 10000),
+            ...     section_id="A",
+            ...     sheet_number="A2",
+            ... )
+        """
+        # Determine look direction from section view's plane normal
+        # The plane normal points in the view direction
+        nx, ny, nz = section_view.plane_normal
+
+        # Calculate line direction vector
+        line_dx = end_point.x - start_point.x
+        line_dy = end_point.y - start_point.y
+        line_length = math.sqrt(line_dx * line_dx + line_dy * line_dy)
+        if line_length > 0:
+            line_dx /= line_length
+            line_dy /= line_length
+
+        # Cross product of line direction and normal determines side
+        # If cross product Z component is positive, looking left; negative, looking right
+        cross_z = line_dx * ny - line_dy * nx
+        look_direction = "left" if cross_z > 0 else "right"
+
+        return cls(
+            start_point=start_point,
+            end_point=end_point,
+            section_id=section_id,
+            sheet_number=sheet_number,
+            look_direction=look_direction,
+            section_view=section_view,
+            style=style or SectionSymbolStyle.default(),
+        )
+
+
 # Type alias for any tag type
-Tag2D = DoorTag | WindowTag | RoomTag
+Tag2D = DoorTag | WindowTag | RoomTag | SectionSymbol

--- a/tests/test_section_symbol.py
+++ b/tests/test_section_symbol.py
@@ -1,0 +1,475 @@
+"""
+Tests for section symbol annotations.
+"""
+
+import math
+
+import pytest
+
+from bimascode.drawing.primitives import Point2D, ViewResult
+from bimascode.drawing.section_view import SectionView
+from bimascode.drawing.tags import SectionSymbol, SectionSymbolStyle
+
+
+class TestSectionSymbolStyle:
+    """Tests for SectionSymbolStyle class."""
+
+    def test_default_style(self):
+        """Test default section symbol style."""
+        style = SectionSymbolStyle.default()
+
+        assert style.bubble_radius == 200.0
+        assert style.text_height == 120.0
+        assert style.arrow_size == 150.0
+        assert style.line_extension == 100.0
+        assert style.show_arrows is True
+        assert style.show_bubbles is True
+
+    def test_custom_style(self):
+        """Test creating a custom style."""
+        style = SectionSymbolStyle(
+            bubble_radius=250.0,
+            text_height=150.0,
+            arrow_size=200.0,
+            line_extension=150.0,
+            show_arrows=False,
+            show_bubbles=True,
+        )
+
+        assert style.bubble_radius == 250.0
+        assert style.text_height == 150.0
+        assert style.arrow_size == 200.0
+        assert style.line_extension == 150.0
+        assert style.show_arrows is False
+        assert style.show_bubbles is True
+
+    def test_style_scale(self):
+        """Test scaling a style."""
+        style = SectionSymbolStyle.default()
+        scaled = style.scale(2.0)
+
+        assert scaled.bubble_radius == style.bubble_radius * 2.0
+        assert scaled.text_height == style.text_height * 2.0
+        assert scaled.arrow_size == style.arrow_size * 2.0
+        assert scaled.line_extension == style.line_extension * 2.0
+        # Boolean properties unchanged
+        assert scaled.show_arrows == style.show_arrows
+        assert scaled.show_bubbles == style.show_bubbles
+
+
+class TestSectionSymbol:
+    """Tests for SectionSymbol class."""
+
+    def test_basic_creation(self):
+        """Test basic section symbol creation."""
+        symbol = SectionSymbol(
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            section_id="A",
+            sheet_number="A2",
+        )
+
+        assert symbol.start_point == Point2D(5000, 0)
+        assert symbol.end_point == Point2D(5000, 10000)
+        assert symbol.section_id == "A"
+        assert symbol.sheet_number == "A2"
+        assert symbol.look_direction == "right"  # default
+
+    def test_labels(self):
+        """Test section symbol labels."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+            section_id="B",
+            sheet_number="S-101",
+        )
+
+        assert symbol.start_label == "B"
+        assert symbol.end_label == "B"
+        assert symbol.start_sheet == "S-101"
+        assert symbol.end_sheet == "S-101"
+
+    def test_line_angle_horizontal(self):
+        """Test line angle for horizontal section."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+        )
+
+        # Horizontal line pointing right = 0 radians
+        assert abs(symbol.line_angle) < 0.001
+
+    def test_line_angle_vertical(self):
+        """Test line angle for vertical section."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(0, 1000),
+        )
+
+        # Vertical line pointing up = pi/2 radians
+        assert abs(symbol.line_angle - math.pi / 2) < 0.001
+
+    def test_line_angle_diagonal(self):
+        """Test line angle for diagonal section."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 1000),
+        )
+
+        # 45 degree line = pi/4 radians
+        assert abs(symbol.line_angle - math.pi / 4) < 0.001
+
+    def test_line_length(self):
+        """Test line length calculation."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(3000, 4000),
+        )
+
+        # 3-4-5 triangle: length = 5000
+        assert abs(symbol.line_length - 5000.0) < 0.001
+
+    def test_arrow_angle_right(self):
+        """Test arrow angle for look_direction='right'."""
+        # Vertical section line going north
+        symbol = SectionSymbol(
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            look_direction="right",
+        )
+
+        # Line angle is pi/2 (pointing up)
+        # Right of that is 0 (pointing east)
+        expected_arrow_angle = math.pi / 2 - math.pi / 2  # = 0
+        assert abs(symbol.arrow_angle - expected_arrow_angle) < 0.001
+
+    def test_arrow_angle_left(self):
+        """Test arrow angle for look_direction='left'."""
+        # Vertical section line going north
+        symbol = SectionSymbol(
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            look_direction="left",
+        )
+
+        # Line angle is pi/2 (pointing up)
+        # Left of that is pi (pointing west)
+        assert abs(symbol.arrow_angle - math.pi) < 0.001
+
+    def test_midpoint(self):
+        """Test midpoint calculation."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 2000),
+        )
+
+        midpoint = symbol.midpoint
+        assert midpoint.x == 500.0
+        assert midpoint.y == 1000.0
+
+    def test_bubble_centers(self):
+        """Test bubble center calculations."""
+        style = SectionSymbolStyle(bubble_radius=200.0, line_extension=100.0)
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),  # Horizontal line pointing right
+            style=style,
+        )
+
+        start_bubble = symbol.get_start_bubble_center()
+        end_bubble = symbol.get_end_bubble_center()
+
+        # Start bubble should be to the left of start point
+        # offset = bubble_radius + line_extension = 300
+        assert abs(start_bubble.x - (-300.0)) < 0.001
+        assert abs(start_bubble.y - 0.0) < 0.001
+
+        # End bubble should be to the right of end point
+        assert abs(end_bubble.x - 1300.0) < 0.001
+        assert abs(end_bubble.y - 0.0) < 0.001
+
+    def test_layer(self):
+        """Test layer property."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+        )
+
+        from bimascode.drawing.line_styles import Layer
+
+        assert symbol.layer == Layer.SYMBOL
+
+    def test_block_name(self):
+        """Test block name generation."""
+        style = SectionSymbolStyle(bubble_radius=200.0, text_height=120.0, arrow_size=150.0)
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+            style=style,
+        )
+
+        assert symbol.block_name == "SECTION_SYMBOL_200_120_150"
+
+    def test_translate(self):
+        """Test translating a section symbol."""
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+            section_id="A",
+            sheet_number="A2",
+        )
+
+        translated = symbol.translate(500, 300)
+
+        assert translated.start_point.x == 500
+        assert translated.start_point.y == 300
+        assert translated.end_point.x == 1500
+        assert translated.end_point.y == 300
+        # Other properties preserved
+        assert translated.section_id == "A"
+        assert translated.sheet_number == "A2"
+
+    def test_scale_and_translate(self):
+        """Test scaling and translating a section symbol."""
+        style = SectionSymbolStyle(bubble_radius=200.0, text_height=120.0)
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(1000, 0),
+            style=style,
+        )
+
+        scaled = symbol.scale_and_translate(0.5, 100, 200)
+
+        # Points scaled and translated
+        assert scaled.start_point.x == 100  # 0 * 0.5 + 100
+        assert scaled.start_point.y == 200  # 0 * 0.5 + 200
+        assert scaled.end_point.x == 600  # 1000 * 0.5 + 100
+        assert scaled.end_point.y == 200  # 0 * 0.5 + 200
+        # Style scaled
+        assert scaled.style.bubble_radius == 100.0  # 200 * 0.5
+        assert scaled.style.text_height == 60.0  # 120 * 0.5
+
+
+class TestSectionSymbolFromSectionView:
+    """Tests for creating SectionSymbol from SectionView."""
+
+    def test_from_section_view_right(self):
+        """Test creating symbol from section view looking right."""
+        section_view = SectionView.from_section_line(
+            name="Section A-A",
+            start_point=(5000, 0),
+            end_point=(5000, 10000),
+            look_direction="right",
+        )
+
+        symbol = SectionSymbol.from_section_view(
+            section_view,
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            section_id="A",
+            sheet_number="A2",
+        )
+
+        assert symbol.section_view == section_view
+        assert symbol.section_id == "A"
+        assert symbol.sheet_number == "A2"
+        assert symbol.look_direction == "right"
+
+    def test_from_section_view_left(self):
+        """Test creating symbol from section view looking left."""
+        section_view = SectionView.from_section_line(
+            name="Section B-B",
+            start_point=(5000, 0),
+            end_point=(5000, 10000),
+            look_direction="left",
+        )
+
+        symbol = SectionSymbol.from_section_view(
+            section_view,
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            section_id="B",
+            sheet_number="A3",
+        )
+
+        assert symbol.look_direction == "left"
+
+
+class TestViewResultWithSectionSymbols:
+    """Tests for ViewResult with section symbol support."""
+
+    @pytest.fixture
+    def section_symbol(self):
+        """Create a section symbol for testing."""
+        return SectionSymbol(
+            start_point=Point2D(5000, 0),
+            end_point=Point2D(5000, 10000),
+            section_id="A",
+            sheet_number="A2",
+        )
+
+    def test_view_result_with_section_symbols(self, section_symbol):
+        """Test ViewResult containing section symbols."""
+        result = ViewResult(section_symbols=[section_symbol])
+
+        assert len(result.section_symbols) == 1
+        assert result.section_symbols[0].section_id == "A"
+
+    def test_view_result_total_count_includes_section_symbols(self, section_symbol):
+        """Test that total_geometry_count includes section symbols."""
+        result = ViewResult(section_symbols=[section_symbol])
+
+        assert result.total_geometry_count == 1
+
+    def test_view_result_extend_with_section_symbols(self, section_symbol):
+        """Test extending ViewResult preserves section symbols."""
+        result1 = ViewResult()
+        result2 = ViewResult(section_symbols=[section_symbol])
+
+        result1.extend(result2)
+
+        assert len(result1.section_symbols) == 1
+        assert result1.section_symbols[0].section_id == "A"
+
+    def test_view_result_translate_with_section_symbols(self, section_symbol):
+        """Test translating ViewResult includes section symbols."""
+        result = ViewResult(section_symbols=[section_symbol])
+
+        original_start = section_symbol.start_point
+
+        translated = result.translate(500, 300)
+
+        assert translated.section_symbols[0].start_point.x == original_start.x + 500
+        assert translated.section_symbols[0].start_point.y == original_start.y + 300
+
+    def test_view_result_scale_and_translate_with_section_symbols(self, section_symbol):
+        """Test scaling and translating ViewResult includes section symbols."""
+        result = ViewResult(section_symbols=[section_symbol])
+
+        scaled = result.scale_and_translate(0.5, 100, 200)
+
+        # start_point was (5000, 0), scaled by 0.5 = (2500, 0), then + (100, 200)
+        assert scaled.section_symbols[0].start_point.x == 2600
+        assert scaled.section_symbols[0].start_point.y == 200
+
+    def test_view_result_bounds_includes_section_symbols(self, section_symbol):
+        """Test that get_bounds includes section symbol positions."""
+        result = ViewResult(section_symbols=[section_symbol])
+
+        bounds = result.get_bounds()
+
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+
+        # Bounds should include section symbol endpoints and bubbles
+        assert min_x <= section_symbol.start_point.x <= max_x
+        assert min_y <= section_symbol.start_point.y <= max_y
+        assert min_x <= section_symbol.end_point.x <= max_x
+        assert min_y <= section_symbol.end_point.y <= max_y
+
+
+class TestSectionSymbolDXFExport:
+    """Tests for section symbol DXF export."""
+
+    def test_dxf_export_section_symbols(self, tmp_path):
+        """Test exporting section symbols to DXF."""
+        from bimascode.drawing.dxf_exporter import DXFExporter
+
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(0, 10000),
+            section_id="A",
+            sheet_number="A2",
+        )
+
+        result = ViewResult(section_symbols=[symbol])
+
+        exporter = DXFExporter()
+        if not exporter.is_available:
+            pytest.skip("ezdxf not available")
+
+        output_path = tmp_path / "test_section_symbol.dxf"
+        success = exporter.export(result, str(output_path))
+
+        assert success is True
+        assert output_path.exists()
+
+    def test_dxf_export_multiple_section_symbols(self, tmp_path):
+        """Test exporting multiple section symbols to DXF."""
+        from bimascode.drawing.dxf_exporter import DXFExporter
+
+        symbols = [
+            SectionSymbol(
+                start_point=Point2D(0, 0),
+                end_point=Point2D(0, 10000),
+                section_id="A",
+                sheet_number="A2",
+            ),
+            SectionSymbol(
+                start_point=Point2D(5000, 0),
+                end_point=Point2D(5000, 10000),
+                section_id="B",
+                sheet_number="A3",
+                look_direction="left",
+            ),
+        ]
+
+        result = ViewResult(section_symbols=symbols)
+
+        exporter = DXFExporter()
+        if not exporter.is_available:
+            pytest.skip("ezdxf not available")
+
+        output_path = tmp_path / "test_multiple_section_symbols.dxf"
+        success = exporter.export(result, str(output_path))
+
+        assert success is True
+        assert output_path.exists()
+
+    def test_dxf_export_section_symbol_no_arrows(self, tmp_path):
+        """Test exporting section symbol without arrows."""
+        from bimascode.drawing.dxf_exporter import DXFExporter
+
+        style = SectionSymbolStyle(show_arrows=False, show_bubbles=True)
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(0, 10000),
+            section_id="C",
+            style=style,
+        )
+
+        result = ViewResult(section_symbols=[symbol])
+
+        exporter = DXFExporter()
+        if not exporter.is_available:
+            pytest.skip("ezdxf not available")
+
+        output_path = tmp_path / "test_section_no_arrows.dxf"
+        success = exporter.export(result, str(output_path))
+
+        assert success is True
+        assert output_path.exists()
+
+    def test_dxf_export_section_symbol_no_bubbles(self, tmp_path):
+        """Test exporting section symbol without bubbles."""
+        from bimascode.drawing.dxf_exporter import DXFExporter
+
+        style = SectionSymbolStyle(show_arrows=True, show_bubbles=False)
+        symbol = SectionSymbol(
+            start_point=Point2D(0, 0),
+            end_point=Point2D(0, 10000),
+            section_id="D",
+            style=style,
+        )
+
+        result = ViewResult(section_symbols=[symbol])
+
+        exporter = DXFExporter()
+        if not exporter.is_available:
+            pytest.skip("ezdxf not available")
+
+        output_path = tmp_path / "test_section_no_bubbles.dxf"
+        success = exporter.export(result, str(output_path))
+
+        assert success is True
+        assert output_path.exists()

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -4,7 +4,6 @@ import pytest
 
 from bimascode.architecture.door import Door
 from bimascode.architecture.wall import Wall
-from bimascode.architecture.window import Window
 from bimascode.drawing.line_styles import LineStyle, LineWeight
 from bimascode.drawing.symbology import (
     ElementSymbology,


### PR DESCRIPTION
## Summary
Implements Issue #38: Sheet class for DXF paperspace layouts, enabling construction document assembly with viewports, title blocks, and annotations.

## Changes

### Core Sheet Implementation
- `Sheet` class with size, number, name, and metadata
- Standard sheet sizes (ISO A0-A4, ANSI A-E, ARCH A-E)
- Viewport management (add, remove, position, scale)
- Title block placement
- Annotation collection
- DXF export (flat modelspace and paperspace modes)

### Supporting Features
- `ChainDimension2D` for continuous baseline dimensioning
- `DoorTag`, `WindowTag`, `RoomTag` for element annotation
- `SectionSymbol` for section line annotation on floor plans
- Viewport labels with view name and scale notation

### Bug Fixes
- Fixed section cutter coordinate projection to match HLR coordinate system

## Test plan
- [x] All 41 sheet tests passing
- [x] Hospital wing example generates sheet with 4 viewports
- [x] Viewport labels display correctly
- [x] Section symbols positioned correctly (no overlap with dimensions)

## Example Output
The hospital wing example now produces:
- Floor plan with 3 section symbols (A, B, C)
- Sheet A-101 with floor plan + 3 section viewports
- All viewports labeled with name and scale

Closes #38