### PR TITLE
Add TitleBlock templates with DXF BLOCK/ATTRIB export (#40)

### DIFF
--- a/examples/example_hospital_wing.py
+++ b/examples/example_hospital_wing.py
@@ -39,6 +39,7 @@ from bimascode.drawing.primitives import (
 )
 from bimascode.drawing.section_view import SectionView
 from bimascode.drawing.sheet import Sheet, SheetMetadata
+from bimascode.drawing.title_block import TitleBlock, TitleBlockField
 from bimascode.drawing.sheet_sizes import SheetSize
 from bimascode.drawing.tags import DoorTag, RoomTag, SectionSymbol, SectionSymbolStyle, TagStyle
 from bimascode.drawing.view_base import ViewRange, ViewScale
@@ -856,9 +857,32 @@ def main():
         name="Section B-B",
     )
 
+    # Add title block from template with project info
+    title_block = TitleBlock.from_template(
+        "standard_arch_d",
+        fields={
+            TitleBlockField.PROJECT_NAME.value: "Hospital Wing - Patient Care Unit",
+            TitleBlockField.PROJECT_ADDRESS.value: "123 Medical Center Drive",
+            TitleBlockField.CLIENT_NAME.value: "Regional Health System",
+            TitleBlockField.SHEET_NAME.value: sheet.name,
+            TitleBlockField.SHEET_NUMBER.value: sheet.number,
+            TitleBlockField.DRAWN_BY.value: "BIMasCode",
+            TitleBlockField.CHECKED_BY.value: "QA",
+            TitleBlockField.DATE.value: datetime.now().strftime("%Y-%m-%d"),
+            TitleBlockField.SCALE.value: "As Noted",
+            TitleBlockField.REVISION.value: "A",
+        },
+        position=(
+            sheet.size.width - 200 - 10,  # Right edge minus title block width minus margin
+            10,  # Bottom margin
+        ),
+    )
+    sheet.set_title_block(title_block)
+
     print(f"  Sheet: {sheet.number} - {sheet.name}")
     print(f"  Size: {sheet.size.name} ({sheet.size.width}mm x {sheet.size.height}mm)")
     print(f"  Viewports: {len(sheet.viewports)}")
+    print(f"  Title block: {title_block.name}")
 
     # Export sheet to DXF
     sheet_dxf_path = output_dir / "hospital_wing_sheet_A101.dxf"

--- a/src/bimascode/drawing/__init__.py
+++ b/src/bimascode/drawing/__init__.py
@@ -78,7 +78,15 @@ from bimascode.drawing.tags import (
     TagStyle,
     WindowTag,
 )
-from bimascode.drawing.title_block import TitleBlock
+from bimascode.drawing.title_block import (
+    TitleBlock,
+    TitleBlockField,
+    TitleBlockFieldDefinition,
+    TitleBlockTemplate,
+    get_title_block_template,
+    list_title_block_templates,
+    register_title_block_template,
+)
 
 # View base classes
 from bimascode.drawing.view_base import (
@@ -148,6 +156,12 @@ __all__ = [
     "SheetSize",
     "SheetViewport",
     "TitleBlock",
+    "TitleBlockField",
+    "TitleBlockFieldDefinition",
+    "TitleBlockTemplate",
+    "get_title_block_template",
+    "list_title_block_templates",
+    "register_title_block_template",
     # Utilities
     "SectionCutter",
     "get_section_cutter",

--- a/src/bimascode/drawing/dxf_exporter.py
+++ b/src/bimascode/drawing/dxf_exporter.py
@@ -22,6 +22,7 @@ from bimascode.drawing.primitives import (
     ViewResult,
 )
 from bimascode.drawing.tags import DoorTag, RoomTag, SectionSymbol, TagShape, WindowTag
+from bimascode.drawing.title_block import TitleBlock
 
 if TYPE_CHECKING:
     from bimascode.drawing.sheet import Sheet
@@ -902,6 +903,143 @@ class DXFExporter:
             is_closed=True,
         )
 
+    def _create_title_block_block(
+        self,
+        doc,
+        title_block: TitleBlock,
+    ) -> str:
+        """Create a title block BLOCK definition with ATTDEF fields.
+
+        Creates a DXF BLOCK containing the title block border geometry
+        and ATTDEF entries for each field defined in the template.
+
+        Args:
+            doc: DXF document
+            title_block: TitleBlock to create block for
+
+        Returns:
+            Block name for referencing
+        """
+        block_name = title_block.block_name
+
+        if block_name in doc.blocks:
+            return block_name
+
+        block = doc.blocks.new(name=block_name)
+
+        # Add border geometry
+        if title_block.geometry:
+            for line in title_block.geometry.lines:
+                block.add_line(
+                    start=(line.start.x, line.start.y),
+                    end=(line.end.x, line.end.y),
+                    dxfattribs={"layer": line.layer},
+                )
+
+        # Add ATTDEF for each template field
+        if title_block.template:
+            for field_def in title_block.template.fields:
+                # Map alignment to DXF values
+                halign = 0  # Left
+                valign = 0  # Baseline
+                if "CENTER" in field_def.alignment:
+                    halign = 4  # Middle center
+                    valign = 2
+                elif "RIGHT" in field_def.alignment:
+                    halign = 2  # Right
+                if "MIDDLE" in field_def.alignment:
+                    valign = 2  # Middle
+
+                block.add_attdef(
+                    tag=field_def.tag,
+                    insert=(field_def.position.x, field_def.position.y),
+                    dxfattribs={
+                        "height": field_def.height,
+                        "halign": halign,
+                        "valign": valign,
+                        "layer": title_block.template.layer,
+                        "prompt": field_def.prompt,
+                    },
+                )
+
+        return block_name
+
+    def _export_title_block(
+        self,
+        doc,
+        msp,
+        title_block: TitleBlock,
+        scale: float = 1.0,
+    ) -> None:
+        """Export a TitleBlock to DXF as a BLOCK reference with ATTRIB.
+
+        Creates the block definition if needed, then inserts a reference
+        at the title block's position with filled attribute values.
+
+        Args:
+            doc: DXF document
+            msp: Modelspace or layout to export to
+            title_block: TitleBlock to export
+            scale: Scale factor (typically 1.0 for sheet space)
+        """
+        # Create block definition
+        block_name = self._create_title_block_block(doc, title_block)
+
+        # Insert block reference at title block position
+        insert_point = (
+            title_block.position.x * scale,
+            title_block.position.y * scale,
+        )
+
+        block_ref = msp.add_blockref(
+            block_name,
+            insert=insert_point,
+            dxfattribs={
+                "layer": title_block.template.layer if title_block.template else Layer.ANNOTATION,
+            },
+        )
+
+        # Add attributes with field values
+        attrib_values = {}
+        if title_block.template:
+            for field_def in title_block.template.fields:
+                value = title_block.fields.get(field_def.tag, "")
+                if value:
+                    attrib_values[field_def.tag] = value
+
+        if attrib_values:
+            block_ref.add_auto_attribs(attrib_values)
+
+    def _export_title_block_flat(
+        self,
+        msp,
+        title_block: TitleBlock,
+        scale: float = 1.0,
+    ) -> None:
+        """Export a TitleBlock to DXF as flat geometry (no blocks).
+
+        Exports border lines and text notes directly without using
+        DXF BLOCK/ATTRIB structures. Useful for maximum compatibility.
+
+        Args:
+            msp: Modelspace or layout to export to
+            title_block: TitleBlock to export
+            scale: Scale factor
+        """
+        # Export border geometry
+        if title_block.geometry:
+            positioned = title_block.get_positioned_geometry()
+            for line in positioned.lines:
+                msp.add_line(
+                    start=(line.start.x * scale, line.start.y * scale),
+                    end=(line.end.x * scale, line.end.y * scale),
+                    dxfattribs={"layer": line.layer},
+                )
+
+        # Export field text as MTEXT
+        text_notes = title_block.get_text_notes()
+        self._export_text_notes(msp, text_notes, scale)
+
     def export_multiple(
         self,
         views: list[tuple[ViewResult, tuple[float, float]]],
@@ -1135,8 +1273,8 @@ class DXFSheetExporter:
             )
 
         # Export title block to paperspace (if present)
-        if sheet.title_block and sheet.title_block.has_geometry():
-            self._export_view_result_to_layout(doc, psp, sheet.title_block.geometry, scale=1.0)
+        if sheet.title_block:
+            self._export_title_block(doc, psp, sheet.title_block, scale=1.0)
 
         # Export sheet annotations to paperspace
         if sheet.annotations.total_geometry_count > 0:
@@ -1333,6 +1471,48 @@ class DXFSheetExporter:
             },
         ).set_location(insert=(center_x, scale_y))
 
+    def _export_title_block(
+        self,
+        doc,
+        layout,
+        title_block: TitleBlock,
+        scale: float = 1.0,
+    ) -> None:
+        """Export a TitleBlock to DXF as a BLOCK reference with ATTRIB.
+
+        Creates the block definition if needed, then inserts a reference
+        at the title block's position with filled attribute values.
+
+        Args:
+            doc: DXF document
+            layout: Layout to export to (modelspace or paperspace)
+            title_block: TitleBlock to export
+            scale: Scale factor (typically 1.0 for sheet space)
+        """
+        self._model_exporter._export_title_block(doc, layout, title_block, scale)
+
+    def _export_title_block_flat(
+        self,
+        doc,
+        layout,
+        title_block: TitleBlock,
+        scale: float = 1.0,
+    ) -> None:
+        """Export a TitleBlock to DXF as flat geometry (no blocks).
+
+        Exports border lines and text notes directly without using
+        DXF BLOCK/ATTRIB structures. Useful for maximum compatibility.
+
+        Args:
+            doc: DXF document
+            layout: Layout to export to
+            title_block: TitleBlock to export
+            scale: Scale factor
+        """
+        # Get full geometry including positioned border and text notes
+        full_geometry = title_block.get_full_geometry()
+        self._export_view_result_to_layout(doc, layout, full_geometry, scale)
+
     def export_sheet_flat(
         self,
         sheet: Sheet,
@@ -1392,8 +1572,8 @@ class DXFSheetExporter:
             self._add_viewport_label(msp, viewport, scaled_view)
 
         # Export title block to modelspace (if present)
-        if sheet.title_block and sheet.title_block.has_geometry():
-            self._export_view_result_to_layout(doc, msp, sheet.title_block.geometry, scale=1.0)
+        if sheet.title_block:
+            self._export_title_block_flat(doc, msp, sheet.title_block, scale=1.0)
 
         # Export sheet annotations to modelspace
         if sheet.annotations.total_geometry_count > 0:

--- a/src/bimascode/drawing/title_block.py
+++ b/src/bimascode/drawing/title_block.py
@@ -1,19 +1,513 @@
 """Title block for drawing sheets.
 
-Defines TitleBlock dataclass for sheet title blocks.
-This is a stub implementation for Issue #40 - full title block features
-including DXF BLOCK/ATTDEF support will be implemented separately.
+Defines TitleBlock class and TitleBlockTemplate for sheet title blocks.
+Supports DXF BLOCK/ATTDEF/ATTRIB export with standard and custom templates.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING
 
-from bimascode.drawing.primitives import Point2D, ViewResult
+from bimascode.drawing.line_styles import Layer, LineStyle
+from bimascode.drawing.primitives import Line2D, Point2D, TextNote2D, ViewResult
 
 if TYPE_CHECKING:
-    pass
+    from bimascode.drawing.sheet import Sheet
+
+
+class TitleBlockField(Enum):
+    """Standard title block field identifiers."""
+
+    PROJECT_NAME = "PROJECT_NAME"
+    PROJECT_NUMBER = "PROJECT_NUMBER"
+    PROJECT_ADDRESS = "PROJECT_ADDRESS"
+    CLIENT_NAME = "CLIENT_NAME"
+    SHEET_NUMBER = "SHEET_NUMBER"
+    SHEET_NAME = "SHEET_NAME"
+    DATE = "DATE"
+    DRAWN_BY = "DRAWN_BY"
+    CHECKED_BY = "CHECKED_BY"
+    APPROVED_BY = "APPROVED_BY"
+    REVISION = "REVISION"
+    SCALE = "SCALE"
+    COMPANY_NAME = "COMPANY_NAME"
+    COMPANY_ADDRESS = "COMPANY_ADDRESS"
+
+
+@dataclass(frozen=True)
+class TitleBlockFieldDefinition:
+    """Definition for a title block attribute field.
+
+    Defines where a text field appears in the title block and its formatting.
+
+    Attributes:
+        tag: DXF attribute tag name (e.g., "PROJECT_NAME")
+        prompt: Prompt text shown when inserting block
+        position: Position relative to title block origin (mm)
+        height: Text height in mm
+        alignment: Text alignment ("LEFT", "CENTER", "RIGHT")
+        default_value: Default value if not provided
+        max_width: Maximum text width for wrapping (0 = no limit)
+    """
+
+    tag: str
+    prompt: str
+    position: Point2D
+    height: float = 2.5
+    alignment: str = "MIDDLE_LEFT"
+    default_value: str = ""
+    max_width: float = 0.0
+
+
+@dataclass
+class TitleBlockTemplate:
+    """Template for title block geometry and fields.
+
+    Defines the graphical layout and field positions for a title block.
+    Templates can be reused across multiple sheets.
+
+    Attributes:
+        name: Template identifier (e.g., "standard_ansi_d")
+        width: Title block width in mm
+        height: Title block height in mm
+        fields: List of field definitions
+        border_offset: Offset from sheet edge to title block border (mm)
+        layer: CAD layer for title block geometry
+    """
+
+    name: str
+    width: float
+    height: float
+    fields: list[TitleBlockFieldDefinition] = field(default_factory=list)
+    border_offset: float = 5.0
+    layer: str = Layer.ANNOTATION
+
+    def generate_geometry(self) -> ViewResult:
+        """Generate the title block border and field geometry.
+
+        Returns:
+            ViewResult containing title block linework
+        """
+        lines: list[Line2D] = []
+        style = LineStyle.default()
+
+        # Outer border
+        lines.extend(
+            [
+                Line2D(Point2D(0, 0), Point2D(self.width, 0), style, self.layer),
+                Line2D(
+                    Point2D(self.width, 0),
+                    Point2D(self.width, self.height),
+                    style,
+                    self.layer,
+                ),
+                Line2D(
+                    Point2D(self.width, self.height),
+                    Point2D(0, self.height),
+                    style,
+                    self.layer,
+                ),
+                Line2D(Point2D(0, self.height), Point2D(0, 0), style, self.layer),
+            ]
+        )
+
+        return ViewResult(lines=lines)
+
+    def get_field_definition(self, tag: str) -> TitleBlockFieldDefinition | None:
+        """Get field definition by tag name.
+
+        Args:
+            tag: Field tag to find
+
+        Returns:
+            Field definition or None if not found
+        """
+        for field_def in self.fields:
+            if field_def.tag == tag:
+                return field_def
+        return None
+
+
+# Standard title block templates
+def _create_standard_ansi_d_template() -> TitleBlockTemplate:
+    """Create standard ANSI D (22x34) title block template.
+
+    Layout with separate rows to prevent text overlap:
+    - Row 1 (top): PROJECT_NAME (full width)
+    - Row 2: PROJECT_ADDRESS
+    - Row 3: CLIENT_NAME (left) | SHEET_NAME (right)
+    - Row 4: DRAWN_BY | CHECKED_BY | DATE | SHEET_NUMBER (right box)
+    - Row 5 (bottom): SCALE | REVISION
+    """
+    fields = [
+        # Top row - Project name (full width)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_NAME.value,
+            prompt="Project Name",
+            position=Point2D(5.0, 43.0),
+            height=4.0,
+            alignment="MIDDLE_LEFT",
+            max_width=170.0,
+        ),
+        # Second row - Project address
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_ADDRESS.value,
+            prompt="Project Address",
+            position=Point2D(5.0, 36.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+            max_width=170.0,
+        ),
+        # Third row - Client (left) and Sheet name (right)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.CLIENT_NAME.value,
+            prompt="Client Name",
+            position=Point2D(5.0, 29.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+            max_width=80.0,
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NAME.value,
+            prompt="Sheet Name",
+            position=Point2D(90.0, 29.0),
+            height=3.0,
+            alignment="MIDDLE_LEFT",
+            max_width=85.0,
+        ),
+        # Fourth row - Personnel info (left) and Sheet number (right, prominent)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DRAWN_BY.value,
+            prompt="Drawn By",
+            position=Point2D(5.0, 18.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.CHECKED_BY.value,
+            prompt="Checked By",
+            position=Point2D(35.0, 18.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DATE.value,
+            prompt="Date",
+            position=Point2D(65.0, 18.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NUMBER.value,
+            prompt="Sheet Number",
+            position=Point2D(155.0, 18.0),
+            height=5.0,
+            alignment="MIDDLE_CENTER",
+        ),
+        # Bottom row - Scale and Revision
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SCALE.value,
+            prompt="Scale",
+            position=Point2D(5.0, 8.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.REVISION.value,
+            prompt="Revision",
+            position=Point2D(155.0, 8.0),
+            height=3.0,
+            alignment="MIDDLE_CENTER",
+        ),
+    ]
+
+    return TitleBlockTemplate(
+        name="standard_ansi_d",
+        width=180.0,
+        height=50.0,
+        fields=fields,
+    )
+
+
+def _create_standard_arch_d_template() -> TitleBlockTemplate:
+    """Create standard ARCH D (24x36) title block template.
+
+    Layout with separate rows to prevent text overlap:
+    - Row 1 (top): PROJECT_NAME (full width)
+    - Row 2: PROJECT_ADDRESS
+    - Row 3: CLIENT_NAME (left) | SHEET_NAME (right)
+    - Row 4: DRAWN_BY | CHECKED_BY | DATE | SHEET_NUMBER (right box)
+    - Row 5 (bottom): SCALE | REVISION
+    """
+    fields = [
+        # Top row - Project name (full width)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_NAME.value,
+            prompt="Project Name",
+            position=Point2D(5.0, 48.0),
+            height=4.5,
+            alignment="MIDDLE_LEFT",
+            max_width=190.0,
+        ),
+        # Second row - Project address
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_ADDRESS.value,
+            prompt="Project Address",
+            position=Point2D(5.0, 40.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+            max_width=190.0,
+        ),
+        # Third row - Client (left) and Sheet name (right)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.CLIENT_NAME.value,
+            prompt="Client Name",
+            position=Point2D(5.0, 32.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+            max_width=90.0,
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NAME.value,
+            prompt="Sheet Name",
+            position=Point2D(100.0, 32.0),
+            height=3.0,
+            alignment="MIDDLE_LEFT",
+            max_width=95.0,
+        ),
+        # Fourth row - Personnel info (left) and Sheet number (right, prominent)
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DRAWN_BY.value,
+            prompt="Drawn By",
+            position=Point2D(5.0, 20.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.CHECKED_BY.value,
+            prompt="Checked By",
+            position=Point2D(40.0, 20.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DATE.value,
+            prompt="Date",
+            position=Point2D(75.0, 20.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NUMBER.value,
+            prompt="Sheet Number",
+            position=Point2D(170.0, 20.0),
+            height=6.0,
+            alignment="MIDDLE_CENTER",
+        ),
+        # Bottom row - Scale and Revision
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SCALE.value,
+            prompt="Scale",
+            position=Point2D(5.0, 8.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.REVISION.value,
+            prompt="Revision",
+            position=Point2D(170.0, 8.0),
+            height=3.0,
+            alignment="MIDDLE_CENTER",
+        ),
+    ]
+
+    return TitleBlockTemplate(
+        name="standard_arch_d",
+        width=200.0,
+        height=55.0,
+        fields=fields,
+    )
+
+
+def _create_standard_iso_a1_template() -> TitleBlockTemplate:
+    """Create standard ISO A1 (594x841) title block template.
+
+    ISO standard title block with metric dimensions.
+    """
+    fields = [
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_NAME.value,
+            prompt="Project Name",
+            position=Point2D(5.0, 35.0),
+            height=4.0,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_NUMBER.value,
+            prompt="Project Number",
+            position=Point2D(5.0, 27.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NAME.value,
+            prompt="Sheet Name",
+            position=Point2D(90.0, 35.0),
+            height=3.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NUMBER.value,
+            prompt="Sheet Number",
+            position=Point2D(155.0, 35.0),
+            height=5.0,
+            alignment="MIDDLE_CENTER",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DRAWN_BY.value,
+            prompt="Drawn By",
+            position=Point2D(90.0, 10.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.CHECKED_BY.value,
+            prompt="Checked By",
+            position=Point2D(115.0, 10.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DATE.value,
+            prompt="Date",
+            position=Point2D(140.0, 10.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SCALE.value,
+            prompt="Scale",
+            position=Point2D(90.0, 4.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.REVISION.value,
+            prompt="Revision",
+            position=Point2D(155.0, 4.0),
+            height=3.0,
+            alignment="MIDDLE_CENTER",
+        ),
+    ]
+
+    return TitleBlockTemplate(
+        name="standard_iso_a1",
+        width=170.0,
+        height=45.0,
+        fields=fields,
+    )
+
+
+def _create_minimal_template() -> TitleBlockTemplate:
+    """Create minimal title block template.
+
+    Simple title block with essential fields only.
+    """
+    fields = [
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.PROJECT_NAME.value,
+            prompt="Project Name",
+            position=Point2D(5.0, 22.0),
+            height=3.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NAME.value,
+            prompt="Sheet Name",
+            position=Point2D(70.0, 22.0),
+            height=3.0,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SHEET_NUMBER.value,
+            prompt="Sheet Number",
+            position=Point2D(115.0, 22.0),
+            height=4.0,
+            alignment="MIDDLE_CENTER",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.DATE.value,
+            prompt="Date",
+            position=Point2D(70.0, 5.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+        TitleBlockFieldDefinition(
+            tag=TitleBlockField.SCALE.value,
+            prompt="Scale",
+            position=Point2D(100.0, 5.0),
+            height=2.5,
+            alignment="MIDDLE_LEFT",
+        ),
+    ]
+
+    return TitleBlockTemplate(
+        name="minimal",
+        width=130.0,
+        height=30.0,
+        fields=fields,
+    )
+
+
+# Registry of built-in templates
+_TITLE_BLOCK_TEMPLATES: dict[str, TitleBlockTemplate] = {}
+
+
+def _init_templates() -> None:
+    """Initialize the built-in template registry."""
+    global _TITLE_BLOCK_TEMPLATES
+    if not _TITLE_BLOCK_TEMPLATES:
+        _TITLE_BLOCK_TEMPLATES = {
+            "standard_ansi_d": _create_standard_ansi_d_template(),
+            "standard_arch_d": _create_standard_arch_d_template(),
+            "standard_iso_a1": _create_standard_iso_a1_template(),
+            "minimal": _create_minimal_template(),
+        }
+
+
+def get_title_block_template(name: str) -> TitleBlockTemplate | None:
+    """Get a registered title block template by name.
+
+    Args:
+        name: Template name (e.g., "standard_ansi_d")
+
+    Returns:
+        Template if found, None otherwise
+    """
+    _init_templates()
+    return _TITLE_BLOCK_TEMPLATES.get(name)
+
+
+def register_title_block_template(template: TitleBlockTemplate) -> None:
+    """Register a custom title block template.
+
+    Args:
+        template: Template to register
+    """
+    _init_templates()
+    _TITLE_BLOCK_TEMPLATES[template.name] = template
+
+
+def list_title_block_templates() -> list[str]:
+    """Get list of all registered template names.
+
+    Returns:
+        List of template names
+    """
+    _init_templates()
+    return list(_TITLE_BLOCK_TEMPLATES.keys())
 
 
 @dataclass
@@ -23,25 +517,34 @@ class TitleBlock:
     A title block contains project information, sheet metadata, and
     graphical elements placed at a standard location on sheets.
 
-    NOTE: This is a placeholder for Issue #40. Full implementation
-    will include parametric fields, company logos, standard templates,
-    and DXF BLOCK/ATTDEF/ATTRIB support.
+    Can be created from a template or with custom geometry.
 
     Attributes:
         name: Title block name/template identifier
         position: Insertion point on sheet (typically lower-right corner)
         fields: Dictionary of field names to values
         geometry: Optional 2D linework for the title block border/graphics
+        template: Optional template this title block is based on
 
     Example:
-        >>> title_block = TitleBlock(
-        ...     name="standard_ansi_d",
+        >>> # From template
+        >>> title_block = TitleBlock.from_template(
+        ...     "standard_ansi_d",
         ...     fields={
         ...         "project_name": "One Harbor Place",
         ...         "sheet_number": "A-101",
         ...         "sheet_name": "Ground Floor Plan",
-        ...         "date": "2026-03-25",
+        ...         "date": "2026-03-17",
         ...         "drawn_by": "BF",
+        ...     }
+        ... )
+
+        >>> # Manual creation
+        >>> title_block = TitleBlock(
+        ...     name="custom",
+        ...     fields={
+        ...         "project_name": "My Project",
+        ...         "sheet_number": "A-101",
         ...     }
         ... )
     """
@@ -50,107 +553,246 @@ class TitleBlock:
     position: Point2D = field(default_factory=lambda: Point2D(0, 0))
     fields: dict[str, str] = field(default_factory=dict)
     geometry: ViewResult | None = None
+    template: TitleBlockTemplate | None = None
+
+    @classmethod
+    def from_template(
+        cls,
+        template_name: str,
+        fields: dict[str, str] | None = None,
+        position: Point2D | tuple[float, float] | None = None,
+    ) -> TitleBlock:
+        """Create a title block from a template.
+
+        Args:
+            template_name: Name of registered template
+            fields: Field values to set
+            position: Optional position override
+
+        Returns:
+            TitleBlock configured from template
+
+        Raises:
+            ValueError: If template not found
+        """
+        template = get_title_block_template(template_name)
+        if template is None:
+            available = ", ".join(list_title_block_templates())
+            raise ValueError(
+                f"Unknown title block template: {template_name}. "
+                f"Available templates: {available}"
+            )
+
+        if isinstance(position, tuple):
+            position = Point2D(position[0], position[1])
+        elif position is None:
+            position = Point2D(0, 0)
+
+        # Generate geometry from template
+        geometry = template.generate_geometry()
+
+        # Create title block
+        tb = cls(
+            name=template_name,
+            position=position,
+            fields=fields.copy() if fields else {},
+            geometry=geometry,
+            template=template,
+        )
+
+        return tb
+
+    @classmethod
+    def from_sheet(
+        cls,
+        sheet: Sheet,
+        template_name: str = "standard_ansi_d",
+    ) -> TitleBlock:
+        """Create a title block pre-populated from sheet metadata.
+
+        Creates a title block positioned at the lower-right corner of the
+        sheet and populates fields from the sheet's metadata.
+
+        Args:
+            sheet: Sheet to get metadata from
+            template_name: Template to use
+
+        Returns:
+            TitleBlock positioned and populated for the sheet
+        """
+        template = get_title_block_template(template_name)
+        if template is None:
+            raise ValueError(f"Unknown title block template: {template_name}")
+
+        # Position at lower-right corner of sheet
+        # Title block origin is at its lower-left corner
+        margin = template.border_offset
+        x = sheet.size.width - template.width - margin
+        y = margin
+
+        # Build fields from sheet metadata
+        fields: dict[str, str] = {
+            TitleBlockField.SHEET_NUMBER.value: sheet.number,
+            TitleBlockField.SHEET_NAME.value: sheet.name,
+        }
+
+        # Add metadata fields
+        metadata = sheet.metadata
+        if metadata.project:
+            fields[TitleBlockField.PROJECT_NAME.value] = metadata.project
+        if metadata.drawn_by:
+            fields[TitleBlockField.DRAWN_BY.value] = metadata.drawn_by
+        if metadata.checked_by:
+            fields[TitleBlockField.CHECKED_BY.value] = metadata.checked_by
+        if metadata.date:
+            fields[TitleBlockField.DATE.value] = metadata.date
+        if metadata.revision:
+            fields[TitleBlockField.REVISION.value] = metadata.revision
+        if metadata.scale:
+            fields[TitleBlockField.SCALE.value] = metadata.scale
+
+        return cls.from_template(
+            template_name,
+            fields=fields,
+            position=(x, y),
+        )
 
     # Common field accessors for convenience
     @property
     def project_name(self) -> str:
         """Get project name field value."""
-        return self.fields.get("project_name", "")
+        return self.fields.get(TitleBlockField.PROJECT_NAME.value, "")
 
     @project_name.setter
     def project_name(self, value: str) -> None:
         """Set project name field value."""
-        self.fields["project_name"] = value
+        self.fields[TitleBlockField.PROJECT_NAME.value] = value
+
+    @property
+    def project_number(self) -> str:
+        """Get project number field value."""
+        return self.fields.get(TitleBlockField.PROJECT_NUMBER.value, "")
+
+    @project_number.setter
+    def project_number(self, value: str) -> None:
+        """Set project number field value."""
+        self.fields[TitleBlockField.PROJECT_NUMBER.value] = value
 
     @property
     def sheet_number(self) -> str:
         """Get sheet number field value."""
-        return self.fields.get("sheet_number", "")
+        return self.fields.get(TitleBlockField.SHEET_NUMBER.value, "")
 
     @sheet_number.setter
     def sheet_number(self, value: str) -> None:
         """Set sheet number field value."""
-        self.fields["sheet_number"] = value
+        self.fields[TitleBlockField.SHEET_NUMBER.value] = value
 
     @property
     def sheet_name(self) -> str:
         """Get sheet name field value."""
-        return self.fields.get("sheet_name", "")
+        return self.fields.get(TitleBlockField.SHEET_NAME.value, "")
 
     @sheet_name.setter
     def sheet_name(self, value: str) -> None:
         """Set sheet name field value."""
-        self.fields["sheet_name"] = value
+        self.fields[TitleBlockField.SHEET_NAME.value] = value
 
     @property
     def date(self) -> str:
         """Get date field value."""
-        return self.fields.get("date", "")
+        return self.fields.get(TitleBlockField.DATE.value, "")
 
     @date.setter
     def date(self, value: str) -> None:
         """Set date field value."""
-        self.fields["date"] = value
+        self.fields[TitleBlockField.DATE.value] = value
 
     @property
     def drawn_by(self) -> str:
         """Get drawn by field value."""
-        return self.fields.get("drawn_by", "")
+        return self.fields.get(TitleBlockField.DRAWN_BY.value, "")
 
     @drawn_by.setter
     def drawn_by(self, value: str) -> None:
         """Set drawn by field value."""
-        self.fields["drawn_by"] = value
+        self.fields[TitleBlockField.DRAWN_BY.value] = value
 
     @property
     def checked_by(self) -> str:
         """Get checked by field value."""
-        return self.fields.get("checked_by", "")
+        return self.fields.get(TitleBlockField.CHECKED_BY.value, "")
 
     @checked_by.setter
     def checked_by(self, value: str) -> None:
         """Set checked by field value."""
-        self.fields["checked_by"] = value
+        self.fields[TitleBlockField.CHECKED_BY.value] = value
 
     @property
     def revision(self) -> str:
         """Get revision field value."""
-        return self.fields.get("revision", "")
+        return self.fields.get(TitleBlockField.REVISION.value, "")
 
     @revision.setter
     def revision(self, value: str) -> None:
         """Set revision field value."""
-        self.fields["revision"] = value
+        self.fields[TitleBlockField.REVISION.value] = value
 
     @property
     def scale(self) -> str:
         """Get scale field value."""
-        return self.fields.get("scale", "")
+        return self.fields.get(TitleBlockField.SCALE.value, "")
 
     @scale.setter
     def scale(self, value: str) -> None:
         """Set scale field value."""
-        self.fields["scale"] = value
+        self.fields[TitleBlockField.SCALE.value] = value
+
+    @property
+    def width(self) -> float:
+        """Get title block width from template or default."""
+        if self.template:
+            return self.template.width
+        return 180.0  # Default width
+
+    @property
+    def height(self) -> float:
+        """Get title block height from template or default."""
+        if self.template:
+            return self.template.height
+        return 50.0  # Default height
+
+    @property
+    def block_name(self) -> str:
+        """Get the DXF block name for this title block.
+
+        Includes template name and dimensions to ensure unique blocks.
+        """
+        return f"TITLE_BLOCK_{self.name}_{int(self.width)}_{int(self.height)}"
 
     def get_field(self, name: str, default: str = "") -> str:
         """Get a field value by name.
 
         Args:
-            name: Field name
+            name: Field name (can be TitleBlockField enum value or string)
             default: Default value if field not found
 
         Returns:
             Field value or default
         """
+        if isinstance(name, TitleBlockField):
+            name = name.value
         return self.fields.get(name, default)
 
     def set_field(self, name: str, value: str) -> None:
         """Set a field value by name.
 
         Args:
-            name: Field name
+            name: Field name (can be TitleBlockField enum value or string)
             value: Field value
         """
+        if isinstance(name, TitleBlockField):
+            name = name.value
         self.fields[name] = value
 
     def has_geometry(self) -> bool:
@@ -160,3 +802,62 @@ class TitleBlock:
             True if geometry is defined and non-empty
         """
         return self.geometry is not None and self.geometry.total_geometry_count > 0
+
+    def get_text_notes(self) -> list[TextNote2D]:
+        """Generate text notes for all field values.
+
+        Creates TextNote2D objects positioned according to the template
+        field definitions.
+
+        Returns:
+            List of TextNote2D for each field with a value
+        """
+        if self.template is None:
+            return []
+
+        notes: list[TextNote2D] = []
+        for field_def in self.template.fields:
+            value = self.fields.get(field_def.tag, "")
+            if not value:
+                continue
+
+            # Calculate absolute position (template position + title block position)
+            abs_x = self.position.x + field_def.position.x
+            abs_y = self.position.y + field_def.position.y
+
+            notes.append(
+                TextNote2D(
+                    position=Point2D(abs_x, abs_y),
+                    content=value,
+                    height=field_def.height,
+                    alignment=field_def.alignment,
+                    width=field_def.max_width,
+                    layer=self.template.layer,
+                )
+            )
+
+        return notes
+
+    def get_positioned_geometry(self) -> ViewResult:
+        """Get title block geometry translated to its position.
+
+        Returns:
+            ViewResult with geometry at the title block's position
+        """
+        if self.geometry is None:
+            return ViewResult()
+
+        # Translate geometry to title block position
+        return self.geometry.translate(self.position.x, self.position.y)
+
+    def get_full_geometry(self) -> ViewResult:
+        """Get complete title block geometry including text fields.
+
+        Returns:
+            ViewResult with border geometry and field text notes
+        """
+        result = self.get_positioned_geometry()
+        text_notes = self.get_text_notes()
+        if text_notes:
+            result.text_notes.extend(text_notes)
+        return result

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -11,8 +11,14 @@ from bimascode.drawing import (
     SheetSize,
     SheetViewport,
     TitleBlock,
+    TitleBlockField,
+    TitleBlockFieldDefinition,
+    TitleBlockTemplate,
     ViewResult,
     ViewScale,
+    get_title_block_template,
+    list_title_block_templates,
+    register_title_block_template,
 )
 
 
@@ -325,6 +331,73 @@ class TestSheetViewport:
         assert bounds == (200, 150, 400, 250)  # center - half, center + half
 
 
+class TestTitleBlockTemplate:
+    """Tests for TitleBlockTemplate class."""
+
+    def test_list_templates(self):
+        """Test listing available templates."""
+        templates = list_title_block_templates()
+        assert "standard_ansi_d" in templates
+        assert "standard_arch_d" in templates
+        assert "standard_iso_a1" in templates
+        assert "minimal" in templates
+
+    def test_get_template(self):
+        """Test getting a template by name."""
+        template = get_title_block_template("standard_ansi_d")
+        assert template is not None
+        assert template.name == "standard_ansi_d"
+        assert template.width == 180.0
+        assert template.height == 50.0
+
+    def test_get_nonexistent_template(self):
+        """Test getting a template that doesn't exist."""
+        template = get_title_block_template("nonexistent")
+        assert template is None
+
+    def test_template_has_fields(self):
+        """Test that templates define fields."""
+        template = get_title_block_template("standard_ansi_d")
+        assert len(template.fields) > 0
+
+        # Check for expected fields
+        tags = [f.tag for f in template.fields]
+        assert TitleBlockField.PROJECT_NAME.value in tags
+        assert TitleBlockField.SHEET_NUMBER.value in tags
+        assert TitleBlockField.SHEET_NAME.value in tags
+        assert TitleBlockField.DATE.value in tags
+
+    def test_template_generate_geometry(self):
+        """Test template geometry generation."""
+        template = get_title_block_template("standard_ansi_d")
+        geometry = template.generate_geometry()
+
+        assert geometry is not None
+        assert len(geometry.lines) == 4  # Border rectangle
+
+    def test_register_custom_template(self):
+        """Test registering a custom template."""
+        custom = TitleBlockTemplate(
+            name="custom_test",
+            width=100.0,
+            height=30.0,
+            fields=[
+                TitleBlockFieldDefinition(
+                    tag="CUSTOM_FIELD",
+                    prompt="Custom Field",
+                    position=Point2D(10, 20),
+                    height=3.0,
+                )
+            ],
+        )
+        register_title_block_template(custom)
+
+        retrieved = get_title_block_template("custom_test")
+        assert retrieved is not None
+        assert retrieved.name == "custom_test"
+        assert len(retrieved.fields) == 1
+
+
 class TestTitleBlock:
     """Tests for TitleBlock class."""
 
@@ -333,14 +406,74 @@ class TestTitleBlock:
         tb = TitleBlock(
             name="standard",
             fields={
-                "project_name": "Test Project",
-                "sheet_number": "A-101",
+                TitleBlockField.PROJECT_NAME.value: "Test Project",
+                TitleBlockField.SHEET_NUMBER.value: "A-101",
             },
         )
 
         assert tb.name == "standard"
         assert tb.project_name == "Test Project"
         assert tb.sheet_number == "A-101"
+
+    def test_title_block_from_template(self):
+        """Test creating title block from template."""
+        tb = TitleBlock.from_template(
+            "standard_ansi_d",
+            fields={
+                TitleBlockField.PROJECT_NAME.value: "One Harbor Place",
+                TitleBlockField.SHEET_NUMBER.value: "A-101",
+                TitleBlockField.SHEET_NAME.value: "Ground Floor Plan",
+            },
+        )
+
+        assert tb.name == "standard_ansi_d"
+        assert tb.project_name == "One Harbor Place"
+        assert tb.sheet_number == "A-101"
+        assert tb.sheet_name == "Ground Floor Plan"
+        assert tb.template is not None
+        assert tb.has_geometry() is True
+
+    def test_title_block_from_template_with_position(self):
+        """Test creating title block with position."""
+        tb = TitleBlock.from_template(
+            "standard_ansi_d",
+            position=(100.0, 50.0),
+        )
+
+        assert tb.position == Point2D(100.0, 50.0)
+
+    def test_title_block_from_invalid_template(self):
+        """Test that invalid template raises error."""
+        with pytest.raises(ValueError, match="Unknown title block template"):
+            TitleBlock.from_template("nonexistent")
+
+    def test_title_block_from_sheet(self):
+        """Test creating title block from sheet metadata."""
+        metadata = SheetMetadata(
+            project="Test Project",
+            drawn_by="BF",
+            checked_by="JS",
+            date="2026-04-26",
+            scale="1:100",
+        )
+        sheet = Sheet(
+            size=SheetSize.ANSI_D,
+            number="A-101",
+            name="Ground Floor",
+            metadata=metadata,
+        )
+
+        tb = TitleBlock.from_sheet(sheet, template_name="standard_ansi_d")
+
+        assert tb.project_name == "Test Project"
+        assert tb.sheet_number == "A-101"
+        assert tb.sheet_name == "Ground Floor"
+        assert tb.drawn_by == "BF"
+        assert tb.checked_by == "JS"
+        assert tb.date == "2026-04-26"
+        # Position should be at lower-right
+        assert tb.position.x > 0
+        assert tb.position.y > 0
 
     def test_title_block_field_setters(self):
         """Test title block field setters."""
@@ -372,6 +505,62 @@ class TestTitleBlock:
             lines=[Line2D(Point2D(0, 0), Point2D(100, 0), LineStyle.default())]
         )
         assert tb.has_geometry() is True
+
+    def test_get_text_notes(self):
+        """Test generating text notes from fields."""
+        tb = TitleBlock.from_template(
+            "standard_ansi_d",
+            fields={
+                TitleBlockField.PROJECT_NAME.value: "Test Project",
+                TitleBlockField.SHEET_NUMBER.value: "A-101",
+            },
+            position=(100.0, 50.0),
+        )
+
+        notes = tb.get_text_notes()
+
+        assert len(notes) == 2
+        # Check that positions are offset by title block position
+        for note in notes:
+            assert note.position.x >= 100.0
+            assert note.position.y >= 50.0
+
+    def test_get_full_geometry(self):
+        """Test getting complete geometry with text."""
+        tb = TitleBlock.from_template(
+            "standard_ansi_d",
+            fields={
+                TitleBlockField.PROJECT_NAME.value: "Test Project",
+            },
+            position=(100.0, 50.0),
+        )
+
+        geometry = tb.get_full_geometry()
+
+        assert len(geometry.lines) == 4  # Border
+        assert len(geometry.text_notes) == 1  # Project name
+
+    def test_width_height_from_template(self):
+        """Test width/height properties from template."""
+        tb = TitleBlock.from_template("standard_ansi_d")
+
+        assert tb.width == 180.0
+        assert tb.height == 50.0
+
+    def test_width_height_defaults(self):
+        """Test width/height defaults without template."""
+        tb = TitleBlock(name="custom")
+
+        assert tb.width == 180.0  # Default
+        assert tb.height == 50.0  # Default
+
+    def test_block_name(self):
+        """Test DXF block name generation."""
+        tb = TitleBlock.from_template("standard_ansi_d")
+
+        block_name = tb.block_name
+        assert "TITLE_BLOCK" in block_name
+        assert "standard_ansi_d" in block_name
 
 
 class TestSheetTitleBlock:
@@ -470,3 +659,120 @@ class TestSheetExport:
 
         assert result is True
         assert filepath.exists()
+
+    def test_export_sheet_with_title_block_flat(self, tmp_path):
+        """Test exporting sheet with title block in flat mode."""
+        import ezdxf
+
+        sheet = Sheet(
+            size=SheetSize.ANSI_D,
+            number="A-101",
+            name="Ground Floor",
+            metadata=SheetMetadata(project="Test Project", drawn_by="BF"),
+        )
+        view_result = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(5000, 0), LineStyle.default())]
+        )
+        sheet.add_viewport(view_result, position=(300, 400), scale="1:100")
+
+        # Add title block from sheet metadata
+        tb = TitleBlock.from_sheet(sheet, template_name="standard_ansi_d")
+        sheet.set_title_block(tb)
+
+        filepath = tmp_path / "sheet_with_tb_flat.dxf"
+        result = sheet.export_dxf(str(filepath), flat=True)
+
+        assert result is True
+        assert filepath.exists()
+
+        # Verify the DXF contains title block geometry
+        doc = ezdxf.readfile(str(filepath))
+        msp = doc.modelspace()
+
+        # Should have lines from title block border
+        lines = list(msp.query("LINE"))
+        assert len(lines) > 4  # View content + title block border + sheet border
+
+        # Should have MTEXT from title block fields
+        texts = list(msp.query("MTEXT"))
+        assert len(texts) > 0
+
+    def test_export_sheet_with_title_block_paperspace(self, tmp_path):
+        """Test exporting sheet with title block in paperspace mode."""
+        import ezdxf
+
+        sheet = Sheet(
+            size=SheetSize.ANSI_D,
+            number="A-102",
+            name="Section View",
+            metadata=SheetMetadata(project="Test Project", drawn_by="BF"),
+        )
+        view_result = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(5000, 0), LineStyle.default())]
+        )
+        sheet.add_viewport(view_result, position=(300, 400), scale="1:100")
+
+        # Add title block
+        tb = TitleBlock.from_sheet(sheet, template_name="standard_ansi_d")
+        sheet.set_title_block(tb)
+
+        filepath = tmp_path / "sheet_with_tb_ps.dxf"
+        result = sheet.export_dxf(str(filepath), flat=False)
+
+        assert result is True
+        assert filepath.exists()
+
+        # Verify the DXF has block definitions
+        doc = ezdxf.readfile(str(filepath))
+
+        # Should have a title block BLOCK definition
+        block_names = [b.name for b in doc.blocks]
+        title_blocks = [n for n in block_names if "TITLE_BLOCK" in n]
+        assert len(title_blocks) > 0
+
+    def test_export_title_block_with_all_fields(self, tmp_path):
+        """Test that all title block fields are exported."""
+        import ezdxf
+
+        sheet = Sheet(
+            size=SheetSize.ANSI_D,
+            number="A-105",
+            name="Full Fields Test",
+        )
+        view_result = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(5000, 0), LineStyle.default())]
+        )
+        sheet.add_viewport(view_result, position=(300, 400), scale="1:100")
+
+        # Create title block with all fields
+        tb = TitleBlock.from_template(
+            "standard_ansi_d",
+            fields={
+                TitleBlockField.PROJECT_NAME.value: "Complete Project",
+                TitleBlockField.PROJECT_ADDRESS.value: "123 Main St",
+                TitleBlockField.CLIENT_NAME.value: "ACME Corp",
+                TitleBlockField.SHEET_NAME.value: "Ground Floor Plan",
+                TitleBlockField.SHEET_NUMBER.value: "A-105",
+                TitleBlockField.DRAWN_BY.value: "JD",
+                TitleBlockField.CHECKED_BY.value: "SM",
+                TitleBlockField.DATE.value: "2026-04-26",
+                TitleBlockField.SCALE.value: "1:100",
+                TitleBlockField.REVISION.value: "A",
+            },
+        )
+        sheet.set_title_block(tb)
+
+        filepath = tmp_path / "full_fields.dxf"
+        result = sheet.export_dxf(str(filepath), flat=True)
+
+        assert result is True
+
+        # Verify all text notes are present
+        doc = ezdxf.readfile(str(filepath))
+        msp = doc.modelspace()
+        texts = list(msp.query("MTEXT"))
+
+        # Should have text for all the fields we set
+        text_contents = [t.text for t in texts]
+        assert any("Complete Project" in t for t in text_contents)
+        assert any("A-105" in t for t in text_contents)


### PR DESCRIPTION
## Summary
- Add `TitleBlockTemplate` class with field definitions and geometry generation
- Add `TitleBlockField` enum for standard field identifiers (PROJECT_NAME, SHEET_NUMBER, etc.)
- Implement built-in templates: `standard_ansi_d`, `standard_arch_d`, `standard_iso_a1`, `minimal`
- Add template registry with `get_title_block_template()`, `register_title_block_template()`, `list_title_block_templates()`
- Add `TitleBlock.from_template()` and `TitleBlock.from_sheet()` factory methods
- Implement DXF export as BLOCK with ATTDEF/ATTRIB for editable fields in CAD software
- Add flat export mode for maximum CAD compatibility
- Update hospital wing example to demonstrate title block usage

## Test plan
- [x] Run `pytest tests/test_sheet.py` - all 59 tests pass
- [x] Run hospital wing example - generates sheet with title block
- [x] Verify DXF output contains title block geometry and text

🤖 Generated with [Claude Code](https://claude.ai/code)