### PR TITLE
Add JSON serialization for 2D primitives and GLTFExporter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dev = [
 viz = [
     "ocp-vscode>=2.0.0",  # OCP CAD Viewer for VS Code
 ]
+server = [
+    "trimesh>=4.0.0",  # glTF export and mesh processing
+    "watchdog>=3.0.0",  # File system watching for live preview
+    "websockets>=12.0",  # WebSocket server for live updates
+]
 
 [project.urls]
 Homepage = "https://github.com/benjaminwfriedman/bimascode"
@@ -110,6 +115,7 @@ ignore = [
 "*/drawing/protocols.py" = ["UP007"]  # Union type alias for backward compatibility
 "*/export/ifc_exporter.py" = ["B904"]  # Re-raising ImportError without from clause
 "*/export/ifc_importer.py" = ["B904"]  # Re-raising ImportError without from clause
+"*/export/gltf_exporter.py" = ["B904"]  # Re-raising ImportError without from clause
 "*/spatial/building.py" = ["B904"]  # Re-raising ImportError without from clause
 "*/spatial/grid.py" = ["B905"]  # zip without strict parameter (Python 3.10 compat)
 

--- a/src/bimascode/drawing/line_styles.py
+++ b/src/bimascode/drawing/line_styles.py
@@ -23,6 +23,13 @@ class LineWeight(Enum):
     FINE = 0.18  # Patterns, secondary projection
     EXTRA_FINE = 0.13  # Annotations, dimension lines
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "name": self.name,
+            "width_mm": self.value,
+        }
+
     @classmethod
     def for_cut_element(cls, is_structural: bool = False) -> LineWeight:
         """Get line weight for a cut element.
@@ -75,6 +82,13 @@ class LineType(Enum):
             LineType.ABOVE_CUT: (4.0, 2.0),
         }
         return patterns.get(self, ())
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "name": self.name,
+            "pattern": list(self.pattern),
+        }
 
 
 @dataclass(frozen=True)
@@ -192,6 +206,15 @@ class LineStyle:
             is_cut=self.is_cut,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "weight": self.weight.to_dict(),
+            "type": self.type.to_dict(),
+            "color": list(self.color) if self.color else None,
+            "is_cut": self.is_cut,
+        }
+
 
 # Standard AIA layer naming conventions
 class Layer:
@@ -221,6 +244,9 @@ class Layer:
     SYMBOL = "G-ANNO-SYMB"
     GRID = "G-GRID"
 
+    # Spatial
+    AREA_BOUNDARY = "A-AREA-BNDY"
+
     @classmethod
     def for_element_type(cls, element_type: str) -> str:
         """Get the appropriate layer for an element type.
@@ -241,5 +267,6 @@ class Layer:
             "Column": cls.COLUMN,
             "Beam": cls.BEAM,
             "Room": cls.ANNOTATION,
+            "RoomSeparator": cls.AREA_BOUNDARY,
         }
         return mapping.get(element_type, "0")

--- a/src/bimascode/drawing/primitives.py
+++ b/src/bimascode/drawing/primitives.py
@@ -98,6 +98,10 @@ class Point2D:
         """Return point as (x, y) tuple."""
         return (self.x, self.y)
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {"x": self.x, "y": self.y}
+
 
 @dataclass
 class Line2D:
@@ -164,6 +168,15 @@ class Line2D:
             style=self.style,
             layer=self.layer,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "start": self.start.to_dict(),
+            "end": self.end.to_dict(),
+            "style": self.style.to_dict(),
+            "layer": self.layer,
+        }
 
 
 @dataclass
@@ -238,6 +251,17 @@ class Arc2D:
             style=self.style,
             layer=self.layer,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "center": self.center.to_dict(),
+            "radius": self.radius,
+            "start_angle": self.start_angle,
+            "end_angle": self.end_angle,
+            "style": self.style.to_dict(),
+            "layer": self.layer,
+        }
 
 
 @dataclass
@@ -334,6 +358,15 @@ class Polyline2D:
             layer=self.layer,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "points": [p.to_dict() for p in self.points],
+            "closed": self.closed,
+            "style": self.style.to_dict(),
+            "layer": self.layer,
+        }
+
 
 @dataclass
 class Hatch2D:
@@ -383,6 +416,17 @@ class Hatch2D:
             color=self.color,
             layer=self.layer,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "boundary": [p.to_dict() for p in self.boundary],
+            "pattern": self.pattern,
+            "scale": self.scale,
+            "rotation": self.rotation,
+            "color": list(self.color) if self.color else None,
+            "layer": self.layer,
+        }
 
 
 class TextAlignment:
@@ -462,6 +506,18 @@ class TextNote2D:
             layer=self.layer,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "position": self.position.to_dict(),
+            "content": self.content,
+            "height": self.height,
+            "alignment": self.alignment,
+            "rotation": self.rotation,
+            "width": self.width,
+            "layer": self.layer,
+        }
+
 
 @dataclass(frozen=True)
 class LinearDimension2D:
@@ -540,6 +596,19 @@ class LinearDimension2D:
             layer=self.layer,
             dimlfac=new_dimlfac,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "start": self.start.to_dict(),
+            "end": self.end.to_dict(),
+            "offset": self.offset,
+            "text": self.text,
+            "precision": self.precision,
+            "style": self.style.to_dict(),
+            "layer": self.layer,
+            "dimlfac": self.dimlfac,
+        }
 
 
 @dataclass(frozen=True)
@@ -643,6 +712,18 @@ class ChainDimension2D:
             layer=self.layer,
             dimlfac=new_dimlfac,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "points": [p.to_dict() for p in self.points],
+            "offset": self.offset,
+            "text": self.text,
+            "precision": self.precision,
+            "style": self.style.to_dict(),
+            "layer": self.layer,
+            "dimlfac": self.dimlfac,
+        }
 
 
 # Import tag types for Geometry2D union
@@ -873,3 +954,28 @@ class ViewResult:
         max_y = max(p.y for p in all_points)
 
         return (min_x, min_y, max_x, max_y)
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary.
+
+        Returns a complete representation of the view result that can be
+        serialized to JSON for web viewers or other consumers.
+        """
+        return {
+            "lines": [line.to_dict() for line in self.lines],
+            "arcs": [arc.to_dict() for arc in self.arcs],
+            "polylines": [pl.to_dict() for pl in self.polylines],
+            "hatches": [h.to_dict() for h in self.hatches],
+            "dimensions": [d.to_dict() for d in self.dimensions],
+            "chain_dimensions": [c.to_dict() for c in self.chain_dimensions],
+            "text_notes": [t.to_dict() for t in self.text_notes],
+            "door_tags": [t.to_dict() for t in self.door_tags],
+            "window_tags": [t.to_dict() for t in self.window_tags],
+            "room_tags": [t.to_dict() for t in self.room_tags],
+            "section_symbols": [s.to_dict() for s in self.section_symbols],
+            "view_name": self.view_name,
+            "generation_time": self.generation_time,
+            "element_count": self.element_count,
+            "cache_hits": self.cache_hits,
+            "total_geometry_count": self.total_geometry_count,
+        }

--- a/src/bimascode/drawing/tags.py
+++ b/src/bimascode/drawing/tags.py
@@ -75,6 +75,17 @@ class TagStyle:
             width=self.width * factor if self.width is not None else None,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "shape": self.shape.value,
+            "size": self.size,
+            "text_height": self.text_height,
+            "show_border": self.show_border,
+            "layer": self.layer,
+            "width": self.width,
+        }
+
     @classmethod
     def door_default(cls) -> TagStyle:
         """Default style for door tags (hexagon)."""
@@ -191,6 +202,18 @@ class DoorTag:
             rotation=self.rotation,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "type": "door_tag",
+            "insertion_point": self.insertion_point.to_dict(),
+            "text": self.text,
+            "style": self.style.to_dict(),
+            "rotation": self.rotation,
+            "layer": self.layer,
+            "block_name": self.block_name,
+        }
+
 
 @dataclass(frozen=True)
 class WindowTag:
@@ -268,6 +291,18 @@ class WindowTag:
             style=self.style.scale(scale),
             rotation=self.rotation,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "type": "window_tag",
+            "insertion_point": self.insertion_point.to_dict(),
+            "text": self.text,
+            "style": self.style.to_dict(),
+            "rotation": self.rotation,
+            "layer": self.layer,
+            "block_name": self.block_name,
+        }
 
 
 @dataclass(frozen=True)
@@ -399,6 +434,21 @@ class RoomTag:
             rotation=self.rotation,
         )
 
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "type": "room_tag",
+            "insertion_point": self.insertion_point.to_dict(),
+            "name_text": self.name_text,
+            "number_text": self.number_text,
+            "text": self.text,
+            "style": self.style.to_dict(),
+            "rotation": self.rotation,
+            "layer": self.layer,
+            "block_name": self.block_name,
+            "calculated_width": self.calculated_width,
+        }
+
 
 @dataclass(frozen=True)
 class SectionSymbolStyle:
@@ -448,6 +498,18 @@ class SectionSymbolStyle:
     def default(cls) -> SectionSymbolStyle:
         """Default style for section symbols."""
         return cls()
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "bubble_radius": self.bubble_radius,
+            "text_height": self.text_height,
+            "arrow_size": self.arrow_size,
+            "line_extension": self.line_extension,
+            "show_arrows": self.show_arrows,
+            "show_bubbles": self.show_bubbles,
+            "layer": self.layer,
+        }
 
 
 @dataclass(frozen=True)
@@ -612,6 +674,27 @@ class SectionSymbol:
             style=self.style.scale(scale),
             rotation=self.rotation,
         )
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "type": "section_symbol",
+            "start_point": self.start_point.to_dict(),
+            "end_point": self.end_point.to_dict(),
+            "section_id": self.section_id,
+            "sheet_number": self.sheet_number,
+            "look_direction": self.look_direction,
+            "style": self.style.to_dict(),
+            "rotation": self.rotation,
+            "layer": self.layer,
+            "block_name": self.block_name,
+            "line_angle": self.line_angle,
+            "line_length": self.line_length,
+            "arrow_angle": self.arrow_angle,
+            "midpoint": self.midpoint.to_dict(),
+            "start_bubble_center": self.get_start_bubble_center().to_dict(),
+            "end_bubble_center": self.get_end_bubble_center().to_dict(),
+        }
 
     @classmethod
     def from_section_view(

--- a/src/bimascode/export/gltf_exporter.py
+++ b/src/bimascode/export/gltf_exporter.py
@@ -1,0 +1,261 @@
+"""
+glTF export functionality for BIM as Code models.
+
+Exports Building geometry to glTF binary format (.glb) for fast web viewing.
+Element metadata (GUID, type, name) is embedded in glTF extras for selection/hover.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..spatial.building import Building
+
+
+# Element type to color mapping (RGB 0-255)
+ELEMENT_COLORS = {
+    "Wall": (200, 200, 200),  # Light gray
+    "Floor": (150, 150, 150),  # Darker gray
+    "Roof": (100, 100, 100),  # Dark gray
+    "Ceiling": (240, 240, 240),  # White-ish
+    "Door": (139, 90, 43),  # Brown
+    "Window": (173, 216, 230),  # Light blue
+    "Column": (160, 160, 170),  # Steel gray
+    "Beam": (160, 160, 170),  # Steel gray
+    "Room": (200, 200, 255),  # Light purple (for visualization)
+    "RoomSeparator": (255, 200, 200),  # Light red
+}
+
+DEFAULT_COLOR = (180, 180, 180)  # Fallback gray
+
+
+class GLTFExporter:
+    """
+    Exports BIM as Code models to glTF binary format.
+
+    glTF is a fast-loading 3D format ideal for web viewers. This exporter
+    tessellates build123d geometry and outputs .glb files with element
+    metadata preserved in mesh extras.
+    """
+
+    def __init__(self):
+        """Initialize the glTF exporter."""
+        self._scene = None
+
+    def export(self, building: "Building", filepath: str | Path) -> None:
+        """
+        Export a building model to glTF binary file.
+
+        Args:
+            building: Building instance to export
+            filepath: Output file path (should end in .glb)
+
+        Raises:
+            ImportError: If trimesh is not installed
+        """
+        glb_bytes = self.export_bytes(building)
+
+        output_path = Path(filepath)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(glb_bytes)
+
+    def export_bytes(self, building: "Building") -> bytes:
+        """
+        Export a building model to glTF binary in memory.
+
+        Args:
+            building: Building instance to export
+
+        Returns:
+            glTF binary data as bytes
+
+        Raises:
+            ImportError: If trimesh is not installed
+        """
+        try:
+            import trimesh
+        except ImportError:
+            raise ImportError(
+                "trimesh is required for glTF export. "
+                "Install it with: pip install bimascode[server]"
+            )
+
+        scene = trimesh.Scene()
+
+        # Process each level
+        for level in building.levels:
+            # Process each element on the level
+            for element in level.elements:
+                mesh = self._element_to_mesh(element, trimesh)
+                if mesh is not None:
+                    # Create unique node name
+                    element_type = element.__class__.__name__
+                    element_name = element.name or element.guid[:8]
+                    node_name = f"{element_type}_{element_name}"
+
+                    # Add to scene
+                    scene.add_geometry(mesh, node_name=node_name)
+
+                    # Process hosted elements (doors, windows in walls)
+                    if hasattr(element, "hosted_elements"):
+                        for hosted in element.hosted_elements:
+                            hosted_mesh = self._element_to_mesh(hosted, trimesh)
+                            if hosted_mesh is not None:
+                                hosted_type = hosted.__class__.__name__
+                                hosted_name = hosted.name or hosted.guid[:8]
+                                hosted_node_name = f"{hosted_type}_{hosted_name}"
+                                scene.add_geometry(hosted_mesh, node_name=hosted_node_name)
+
+        # Handle empty scenes
+        if len(scene.geometry) == 0:
+            # Add a tiny placeholder geometry for empty scenes
+            placeholder = trimesh.creation.box(extents=[1, 1, 1])
+            placeholder.metadata["type"] = "placeholder"
+            placeholder.metadata["guid"] = "empty"
+            scene.add_geometry(placeholder, node_name="placeholder")
+
+        # Export to GLB bytes
+        return scene.export(file_type="glb")
+
+    def _element_to_mesh(self, element: Any, trimesh) -> Any | None:
+        """
+        Convert a BIM element to a trimesh mesh.
+
+        Args:
+            element: Element with get_world_geometry() method
+            trimesh: The trimesh module
+
+        Returns:
+            trimesh.Trimesh with metadata, or None if conversion failed
+        """
+        # Get world geometry
+        if not hasattr(element, "get_world_geometry"):
+            return None
+
+        try:
+            world_geom = element.get_world_geometry()
+            if world_geom is None:
+                return None
+        except Exception:
+            # Some elements may not have valid geometry
+            return None
+
+        # Tessellate the geometry
+        try:
+            mesh = self._tessellate_shape(world_geom, trimesh)
+            if mesh is None:
+                return None
+        except Exception:
+            return None
+
+        # Get element type for coloring
+        element_type = element.__class__.__name__
+        color = ELEMENT_COLORS.get(element_type, DEFAULT_COLOR)
+
+        # Apply color as vertex colors (RGBA)
+        if hasattr(mesh, "visual"):
+            mesh.visual.face_colors = [(*color, 255)] * len(mesh.faces)
+
+        # Store metadata in mesh extras (accessible via mesh.metadata)
+        mesh.metadata["guid"] = element.guid
+        mesh.metadata["type"] = element_type
+        mesh.metadata["name"] = element.name or ""
+
+        # Add level info if available
+        if hasattr(element, "level") and element.level is not None:
+            mesh.metadata["level"] = element.level.name
+
+        # Add any custom properties
+        if hasattr(element, "properties"):
+            for key, value in element.properties.items():
+                # Only include JSON-serializable values
+                if isinstance(value, (str, int, float, bool)):
+                    mesh.metadata[f"prop_{key}"] = value
+
+        return mesh
+
+    def _tessellate_shape(self, shape: Any, trimesh) -> Any | None:
+        """
+        Tessellate a build123d/OCCT shape to a trimesh mesh.
+
+        Args:
+            shape: build123d geometry (Part, Solid, Compound)
+            trimesh: The trimesh module
+
+        Returns:
+            trimesh.Trimesh or None if tessellation failed
+        """
+        try:
+            from OCP.BRep import BRep_Tool
+            from OCP.BRepMesh import BRepMesh_IncrementalMesh
+            from OCP.TopAbs import TopAbs_FACE
+            from OCP.TopExp import TopExp_Explorer
+            from OCP.TopLoc import TopLoc_Location
+            from OCP.TopoDS import TopoDS
+        except ImportError:
+            raise ImportError(
+                "OCP (OpenCASCADE) is required for tessellation. "
+                "This should be installed with build123d."
+            )
+
+        # Get the wrapped OCCT shape
+        if hasattr(shape, "wrapped"):
+            occ_shape = shape.wrapped
+        else:
+            occ_shape = shape
+
+        # Mesh the shape
+        # Linear deflection of 1.0mm, angular deflection 0.5 radians
+        mesh = BRepMesh_IncrementalMesh(occ_shape, 1.0, False, 0.5, True)
+        mesh.Perform()
+
+        if not mesh.IsDone():
+            return None
+
+        # Extract triangles from all faces
+        all_vertices = []
+        all_faces = []
+        vertex_offset = 0
+
+        explorer = TopExp_Explorer(occ_shape, TopAbs_FACE)
+        while explorer.More():
+            # Cast to TopoDS_Face
+            face = TopoDS.Face_s(explorer.Current())
+            location = TopLoc_Location()
+
+            triangulation = BRep_Tool.Triangulation_s(face, location)
+            if triangulation is None:
+                explorer.Next()
+                continue
+
+            # Get transformation
+            transform = location.Transformation()
+
+            # Extract vertices (OCCT indices are 1-based)
+            for i in range(1, triangulation.NbNodes() + 1):
+                node = triangulation.Node(i)
+                # Apply transformation
+                transformed = node.Transformed(transform)
+                all_vertices.append([transformed.X(), transformed.Y(), transformed.Z()])
+
+            # Extract triangles (OCCT indices are 1-based)
+            for i in range(1, triangulation.NbTriangles() + 1):
+                tri = triangulation.Triangle(i)
+                n1, n2, n3 = tri.Get()
+                # Adjust indices (OCCT is 1-based, trimesh is 0-based)
+                all_faces.append(
+                    [
+                        n1 - 1 + vertex_offset,
+                        n2 - 1 + vertex_offset,
+                        n3 - 1 + vertex_offset,
+                    ]
+                )
+
+            vertex_offset += triangulation.NbNodes()
+            explorer.Next()
+
+        if not all_vertices or not all_faces:
+            return None
+
+        # Create trimesh mesh
+        return trimesh.Trimesh(vertices=all_vertices, faces=all_faces)

--- a/tests/test_gltf_exporter.py
+++ b/tests/test_gltf_exporter.py
@@ -1,0 +1,306 @@
+"""Tests for glTF export functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from bimascode.architecture import Wall, create_basic_wall_type
+from bimascode.spatial.building import Building
+from bimascode.spatial.level import Level
+from bimascode.utils.materials import MaterialLibrary
+
+# Skip all tests if trimesh is not installed
+pytest.importorskip("trimesh")
+
+
+class TestGLTFExporter:
+    """Tests for GLTFExporter class."""
+
+    @pytest.fixture
+    def simple_building(self):
+        """Create a simple building with one wall for testing."""
+        building = Building("Test Building")
+        level = Level(building, "Ground", elevation=0)
+
+        # Create a simple wall type
+        material = MaterialLibrary.concrete()
+        wall_type = create_basic_wall_type("Test Wall", 200, material)
+
+        # Create a wall
+        Wall(
+            wall_type=wall_type,
+            start_point=(0, 0),
+            end_point=(5000, 0),
+            level=level,
+            height=3000,
+        )
+
+        return building
+
+    @pytest.fixture
+    def building_with_door(self):
+        """Create a building with a wall and door."""
+        from bimascode.architecture.door import Door
+        from bimascode.architecture.door_type import DoorType
+
+        building = Building("Test Building with Door")
+        level = Level(building, "Ground", elevation=0)
+
+        # Create wall
+        material = MaterialLibrary.concrete()
+        wall_type = create_basic_wall_type("Test Wall", 200, material)
+        wall = Wall(
+            wall_type=wall_type,
+            start_point=(0, 0),
+            end_point=(5000, 0),
+            level=level,
+            height=3000,
+        )
+
+        # Create door
+        door_type = DoorType("Single Door", width=900, height=2100)
+        Door(door_type=door_type, host_wall=wall, offset=2000, mark="101")
+
+        return building
+
+    def test_import_gltf_exporter(self):
+        """GLTFExporter can be imported."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        assert exporter is not None
+
+    def test_export_bytes_returns_bytes(self, simple_building):
+        """export_bytes() returns bytes."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        result = exporter.export_bytes(simple_building)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_export_bytes_is_valid_glb(self, simple_building):
+        """Exported bytes are valid GLB format."""
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(simple_building)
+
+        # GLB magic number is 'glTF' (0x46546C67)
+        assert glb_bytes[:4] == b"glTF"
+
+        # Should be loadable by trimesh
+        import io
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+        assert scene is not None
+
+    def test_export_to_file(self, simple_building):
+        """export() writes valid GLB file."""
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "test.glb"
+            exporter.export(simple_building, filepath)
+
+            # File should exist
+            assert filepath.exists()
+
+            # File should be valid GLB
+            scene = trimesh.load(str(filepath))
+            assert scene is not None
+
+    def test_export_creates_parent_directories(self, simple_building):
+        """export() creates parent directories if they don't exist."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "subdir" / "another" / "test.glb"
+            exporter.export(simple_building, filepath)
+
+            assert filepath.exists()
+
+    def test_exported_scene_has_geometry(self, simple_building):
+        """Exported scene contains geometry from the building."""
+        import io
+
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(simple_building)
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+
+        # Scene should have geometry
+        assert len(scene.geometry) > 0
+
+    def test_mesh_metadata_contains_guid(self, simple_building):
+        """Mesh metadata includes element GUID."""
+        import io
+
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(simple_building)
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+
+        # At least one mesh should have GUID in metadata
+        has_guid = False
+        for _name, geom in scene.geometry.items():
+            if hasattr(geom, "metadata") and "guid" in geom.metadata:
+                has_guid = True
+                # GUID should be a string
+                assert isinstance(geom.metadata["guid"], str)
+                break
+
+        assert has_guid, "No mesh found with GUID in metadata"
+
+    def test_mesh_metadata_contains_type(self, simple_building):
+        """Mesh metadata includes element type."""
+        import io
+
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(simple_building)
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+
+        # At least one mesh should have type in metadata
+        has_type = False
+        for _name, geom in scene.geometry.items():
+            if hasattr(geom, "metadata") and "type" in geom.metadata:
+                has_type = True
+                # Type should be "Wall"
+                assert geom.metadata["type"] == "Wall"
+                break
+
+        assert has_type, "No mesh found with type in metadata"
+
+    def test_empty_building_exports(self):
+        """Empty building (no elements) exports without error."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        building = Building("Empty Building")
+        Level(building, "Ground", elevation=0)
+
+        exporter = GLTFExporter()
+        result = exporter.export_bytes(building)
+
+        # Should return valid GLB even if empty
+        assert isinstance(result, bytes)
+        assert result[:4] == b"glTF"
+
+    def test_building_with_door_exports(self, building_with_door):
+        """Building with hosted elements (doors) exports correctly."""
+        import io
+
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(building_with_door)
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+
+        # Should have multiple geometries (wall + door)
+        assert len(scene.geometry) >= 1  # At least the wall
+
+    def test_element_colors_applied(self, simple_building):
+        """Elements have colors applied based on type."""
+        import io
+
+        import trimesh
+
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+        glb_bytes = exporter.export_bytes(simple_building)
+
+        scene = trimesh.load(io.BytesIO(glb_bytes), file_type="glb")
+
+        # Check that geometry has visual colors
+        for _name, geom in scene.geometry.items():
+            if hasattr(geom, "visual") and geom.visual is not None:
+                # Visual should have face colors
+                if hasattr(geom.visual, "face_colors"):
+                    assert geom.visual.face_colors is not None
+
+
+class TestGLTFExporterEdgeCases:
+    """Edge case tests for GLTFExporter."""
+
+    @pytest.fixture
+    def simple_building(self):
+        """Create a simple building with one wall for testing."""
+        building = Building("Test Building")
+        level = Level(building, "Ground", elevation=0)
+
+        material = MaterialLibrary.concrete()
+        wall_type = create_basic_wall_type("Test Wall", 200, material)
+
+        Wall(
+            wall_type=wall_type,
+            start_point=(0, 0),
+            end_point=(5000, 0),
+            level=level,
+            height=3000,
+        )
+
+        return building
+
+    def test_building_with_multiple_levels(self):
+        """Building with multiple levels exports correctly."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        building = Building("Multi-Level Building")
+        level1 = Level(building, "Ground", elevation=0)
+        level2 = Level(building, "First Floor", elevation=3000)
+
+        material = MaterialLibrary.concrete()
+        wall_type = create_basic_wall_type("Test Wall", 200, material)
+
+        # Walls on different levels
+        Wall(wall_type, (0, 0), (5000, 0), level1, height=3000)
+        Wall(wall_type, (0, 0), (5000, 0), level2, height=3000)
+
+        exporter = GLTFExporter()
+        result = exporter.export_bytes(building)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_path_string_and_pathlib(self, simple_building):
+        """export() accepts both str and Path for filepath."""
+        from bimascode.export.gltf_exporter import GLTFExporter
+
+        exporter = GLTFExporter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Test with str
+            str_path = f"{tmpdir}/test_str.glb"
+            exporter.export(simple_building, str_path)
+            assert Path(str_path).exists()
+
+            # Test with Path
+            path_obj = Path(tmpdir) / "test_path.glb"
+            exporter.export(simple_building, path_obj)
+            assert path_obj.exists()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,391 @@
+"""Tests for JSON serialization of 2D primitives and ViewResult."""
+
+import json
+import math
+
+from bimascode.drawing.line_styles import LineStyle, LineType, LineWeight
+from bimascode.drawing.primitives import (
+    Arc2D,
+    ChainDimension2D,
+    Hatch2D,
+    Line2D,
+    LinearDimension2D,
+    Point2D,
+    Polyline2D,
+    TextNote2D,
+    ViewResult,
+)
+
+
+class TestPoint2DSerialization:
+    """Tests for Point2D.to_dict()."""
+
+    def test_basic_point(self):
+        """Point2D serializes to x/y dict."""
+        point = Point2D(100.0, 200.0)
+        result = point.to_dict()
+
+        assert result == {"x": 100.0, "y": 200.0}
+
+    def test_negative_coordinates(self):
+        """Negative coordinates serialize correctly."""
+        point = Point2D(-50.5, -100.25)
+        result = point.to_dict()
+
+        assert result["x"] == -50.5
+        assert result["y"] == -100.25
+
+    def test_json_serializable(self):
+        """Point2D.to_dict() is JSON serializable."""
+        point = Point2D(1000.0, 2000.0)
+        # Should not raise
+        json_str = json.dumps(point.to_dict())
+        parsed = json.loads(json_str)
+        assert parsed == {"x": 1000.0, "y": 2000.0}
+
+
+class TestLineStyleSerialization:
+    """Tests for LineStyle and related enum serialization."""
+
+    def test_line_weight_to_dict(self):
+        """LineWeight serializes with name and width."""
+        weight = LineWeight.HEAVY
+        result = weight.to_dict()
+
+        assert result["name"] == "HEAVY"
+        assert result["width_mm"] == 0.70
+
+    def test_line_type_to_dict(self):
+        """LineType serializes with name and pattern."""
+        line_type = LineType.DASHED
+        result = line_type.to_dict()
+
+        assert result["name"] == "DASHED"
+        assert result["pattern"] == [6.0, 3.0]
+
+    def test_continuous_line_type(self):
+        """Continuous line type has empty pattern."""
+        line_type = LineType.CONTINUOUS
+        result = line_type.to_dict()
+
+        assert result["name"] == "CONTINUOUS"
+        assert result["pattern"] == []
+
+    def test_line_style_to_dict(self):
+        """LineStyle serializes all properties."""
+        style = LineStyle(
+            weight=LineWeight.MEDIUM,
+            type=LineType.CENTER,
+            color=(255, 0, 0),
+            is_cut=True,
+        )
+        result = style.to_dict()
+
+        assert result["weight"]["name"] == "MEDIUM"
+        assert result["type"]["name"] == "CENTER"
+        assert result["color"] == [255, 0, 0]
+        assert result["is_cut"] is True
+
+    def test_line_style_no_color(self):
+        """LineStyle with no color serializes as None."""
+        style = LineStyle.default()
+        result = style.to_dict()
+
+        assert result["color"] is None
+
+    def test_line_style_json_serializable(self):
+        """LineStyle.to_dict() is JSON serializable."""
+        style = LineStyle.cut_heavy()
+        json_str = json.dumps(style.to_dict())
+        parsed = json.loads(json_str)
+        assert parsed["weight"]["name"] == "HEAVY"
+
+
+class TestLine2DSerialization:
+    """Tests for Line2D.to_dict()."""
+
+    def test_basic_line(self):
+        """Line2D serializes start, end, style, layer."""
+        line = Line2D(
+            start=Point2D(0, 0),
+            end=Point2D(1000, 500),
+            style=LineStyle.default(),
+            layer="A-WALL",
+        )
+        result = line.to_dict()
+
+        assert result["start"] == {"x": 0, "y": 0}
+        assert result["end"] == {"x": 1000, "y": 500}
+        assert result["layer"] == "A-WALL"
+        assert "style" in result
+
+    def test_json_serializable(self):
+        """Line2D.to_dict() is JSON serializable."""
+        line = Line2D(
+            start=Point2D(0, 0),
+            end=Point2D(100, 100),
+            style=LineStyle.cut_heavy(),
+        )
+        json_str = json.dumps(line.to_dict())
+        parsed = json.loads(json_str)
+        assert parsed["start"]["x"] == 0
+        assert parsed["end"]["y"] == 100
+
+
+class TestArc2DSerialization:
+    """Tests for Arc2D.to_dict()."""
+
+    def test_basic_arc(self):
+        """Arc2D serializes all properties."""
+        arc = Arc2D(
+            center=Point2D(500, 500),
+            radius=100.0,
+            start_angle=0.0,
+            end_angle=math.pi,
+            style=LineStyle.default(),
+            layer="A-DOOR",
+        )
+        result = arc.to_dict()
+
+        assert result["center"] == {"x": 500, "y": 500}
+        assert result["radius"] == 100.0
+        assert result["start_angle"] == 0.0
+        assert result["end_angle"] == math.pi
+        assert result["layer"] == "A-DOOR"
+
+    def test_json_serializable(self):
+        """Arc2D.to_dict() is JSON serializable."""
+        arc = Arc2D(
+            center=Point2D(0, 0),
+            radius=50.0,
+            start_angle=0.0,
+            end_angle=math.pi / 2,
+            style=LineStyle.default(),
+        )
+        json_str = json.dumps(arc.to_dict())
+        assert "center" in json_str
+
+
+class TestPolyline2DSerialization:
+    """Tests for Polyline2D.to_dict()."""
+
+    def test_basic_polyline(self):
+        """Polyline2D serializes points and properties."""
+        polyline = Polyline2D(
+            points=[Point2D(0, 0), Point2D(100, 0), Point2D(100, 100)],
+            closed=True,
+            style=LineStyle.default(),
+            layer="A-WALL",
+        )
+        result = polyline.to_dict()
+
+        assert len(result["points"]) == 3
+        assert result["points"][0] == {"x": 0, "y": 0}
+        assert result["closed"] is True
+        assert result["layer"] == "A-WALL"
+
+    def test_json_serializable(self):
+        """Polyline2D.to_dict() is JSON serializable."""
+        polyline = Polyline2D(
+            points=[Point2D(0, 0), Point2D(100, 100)],
+            closed=False,
+        )
+        json_str = json.dumps(polyline.to_dict())
+        parsed = json.loads(json_str)
+        assert len(parsed["points"]) == 2
+
+
+class TestHatch2DSerialization:
+    """Tests for Hatch2D.to_dict()."""
+
+    def test_basic_hatch(self):
+        """Hatch2D serializes boundary and properties."""
+        hatch = Hatch2D(
+            boundary=[Point2D(0, 0), Point2D(100, 0), Point2D(100, 100), Point2D(0, 100)],
+            pattern="SOLID",
+            scale=1.0,
+            rotation=45.0,
+            color=(128, 128, 128),
+            layer="A-WALL",
+        )
+        result = hatch.to_dict()
+
+        assert len(result["boundary"]) == 4
+        assert result["pattern"] == "SOLID"
+        assert result["scale"] == 1.0
+        assert result["rotation"] == 45.0
+        assert result["color"] == [128, 128, 128]
+        assert result["layer"] == "A-WALL"
+
+    def test_no_color(self):
+        """Hatch2D with no color serializes as None."""
+        hatch = Hatch2D(
+            boundary=[Point2D(0, 0), Point2D(100, 0), Point2D(100, 100)],
+        )
+        result = hatch.to_dict()
+        assert result["color"] is None
+
+
+class TestTextNote2DSerialization:
+    """Tests for TextNote2D.to_dict()."""
+
+    def test_basic_text_note(self):
+        """TextNote2D serializes all properties."""
+        text = TextNote2D(
+            position=Point2D(500, 500),
+            content="Hello World",
+            height=150.0,
+            alignment="MIDDLE_CENTER",
+            rotation=0.0,
+            width=500.0,
+            layer="G-ANNO",
+        )
+        result = text.to_dict()
+
+        assert result["position"] == {"x": 500, "y": 500}
+        assert result["content"] == "Hello World"
+        assert result["height"] == 150.0
+        assert result["alignment"] == "MIDDLE_CENTER"
+        assert result["rotation"] == 0.0
+        assert result["width"] == 500.0
+        assert result["layer"] == "G-ANNO"
+
+
+class TestDimensionSerialization:
+    """Tests for LinearDimension2D and ChainDimension2D serialization."""
+
+    def test_linear_dimension(self):
+        """LinearDimension2D serializes all properties."""
+        dim = LinearDimension2D(
+            start=Point2D(0, 0),
+            end=Point2D(1000, 0),
+            offset=200.0,
+            text="<>",
+            precision=0,
+            style=LineStyle.dimension(),
+            layer="G-ANNO-DIMS",
+            dimlfac=1.0,
+        )
+        result = dim.to_dict()
+
+        assert result["start"] == {"x": 0, "y": 0}
+        assert result["end"] == {"x": 1000, "y": 0}
+        assert result["offset"] == 200.0
+        assert result["text"] == "<>"
+        assert result["precision"] == 0
+        assert result["dimlfac"] == 1.0
+
+    def test_chain_dimension(self):
+        """ChainDimension2D serializes all points."""
+        chain = ChainDimension2D(
+            points=(Point2D(0, 0), Point2D(1000, 0), Point2D(2500, 0)),
+            offset=300.0,
+        )
+        result = chain.to_dict()
+
+        assert len(result["points"]) == 3
+        assert result["offset"] == 300.0
+
+
+class TestViewResultSerialization:
+    """Tests for ViewResult.to_dict()."""
+
+    def test_empty_view_result(self):
+        """Empty ViewResult serializes with empty lists."""
+        view = ViewResult(view_name="Test View")
+        result = view.to_dict()
+
+        assert result["lines"] == []
+        assert result["arcs"] == []
+        assert result["polylines"] == []
+        assert result["hatches"] == []
+        assert result["dimensions"] == []
+        assert result["chain_dimensions"] == []
+        assert result["text_notes"] == []
+        assert result["door_tags"] == []
+        assert result["window_tags"] == []
+        assert result["room_tags"] == []
+        assert result["section_symbols"] == []
+        assert result["view_name"] == "Test View"
+        assert result["total_geometry_count"] == 0
+
+    def test_view_result_with_geometry(self):
+        """ViewResult with geometry serializes correctly."""
+        view = ViewResult(
+            lines=[
+                Line2D(Point2D(0, 0), Point2D(100, 0), LineStyle.default()),
+                Line2D(Point2D(100, 0), Point2D(100, 100), LineStyle.default()),
+            ],
+            arcs=[
+                Arc2D(Point2D(50, 50), 25.0, 0.0, math.pi, LineStyle.default()),
+            ],
+            view_name="Ground Floor Plan",
+            generation_time=0.5,
+            element_count=10,
+            cache_hits=5,
+        )
+        result = view.to_dict()
+
+        assert len(result["lines"]) == 2
+        assert len(result["arcs"]) == 1
+        assert result["view_name"] == "Ground Floor Plan"
+        assert result["generation_time"] == 0.5
+        assert result["element_count"] == 10
+        assert result["cache_hits"] == 5
+        assert result["total_geometry_count"] == 3
+
+    def test_view_result_json_serializable(self):
+        """ViewResult.to_dict() is fully JSON serializable."""
+        view = ViewResult(
+            lines=[Line2D(Point2D(0, 0), Point2D(100, 100), LineStyle.cut_heavy())],
+            polylines=[
+                Polyline2D(
+                    [Point2D(0, 0), Point2D(50, 50), Point2D(100, 0)],
+                    closed=True,
+                )
+            ],
+            hatches=[
+                Hatch2D(
+                    [Point2D(0, 0), Point2D(100, 0), Point2D(100, 100)],
+                    color=(200, 200, 200),
+                )
+            ],
+            view_name="Test",
+        )
+        # Should not raise
+        json_str = json.dumps(view.to_dict())
+        parsed = json.loads(json_str)
+
+        assert len(parsed["lines"]) == 1
+        assert len(parsed["polylines"]) == 1
+        assert len(parsed["hatches"]) == 1
+        assert parsed["view_name"] == "Test"
+
+
+class TestRoundTrip:
+    """Tests that serialized data can be used to reconstruct objects."""
+
+    def test_point_round_trip(self):
+        """Point data can be extracted from serialized form."""
+        original = Point2D(123.456, 789.012)
+        data = original.to_dict()
+
+        # Reconstruct
+        reconstructed = Point2D(data["x"], data["y"])
+        assert reconstructed.x == original.x
+        assert reconstructed.y == original.y
+
+    def test_line_style_data_accessible(self):
+        """LineStyle data is accessible from serialized form."""
+        style = LineStyle(
+            weight=LineWeight.HEAVY,
+            type=LineType.DASHED,
+            color=(255, 128, 0),
+            is_cut=True,
+        )
+        data = style.to_dict()
+
+        # Access nested data
+        assert data["weight"]["width_mm"] == 0.70
+        assert data["type"]["pattern"] == [6.0, 3.0]
+        assert data["color"] == [255, 128, 0]


### PR DESCRIPTION
## Summary

Implements #121 - Serialization + GLTFExporter

- Add `to_dict()` methods to all 2D primitives for JSON serialization
- Add `GLTFExporter` for fast 3D web viewer export
- Add `[server]` optional dependencies (trimesh, watchdog, websockets)
- Add comprehensive tests (38 new tests)

## Changes

### JSON Serialization
All 2D primitives and view components now have `to_dict()` methods that return JSON-serializable dictionaries:
- `Point2D`, `Line2D`, `Arc2D`, `Polyline2D`, `Hatch2D`
- `LinearDimension2D`, `ChainDimension2D`, `TextNote2D`
- `LineWeight`, `LineType`, `LineStyle`
- `DoorTag`, `WindowTag`, `RoomTag`, `SectionSymbol`
- `ViewResult` (complete view output)

### GLTFExporter
New `src/bimascode/export/gltf_exporter.py`:
- `export(building, filepath)` - Write to .glb file
- `export_bytes(building)` - Return .glb as bytes (for streaming)
- Tessellates OCCT geometry to triangles via OpenCASCADE
- Embeds element metadata in glTF extras: `guid`, `type`, `name`, `level`
- Applies colors based on element type (walls gray, doors brown, etc.)

### Dependencies
New `[server]` optional dependencies in pyproject.toml:
```toml
[project.optional-dependencies]
server = [
    "trimesh>=4.0.0",
    "watchdog>=3.0.0", 
    "websockets>=12.0",
]
```

## Test plan

- [x] `pytest tests/test_serialization.py` - 25 tests for serialization
- [x] `pytest tests/test_gltf_exporter.py` - 13 tests for glTF export  
- [x] `black` formatting passes
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)